### PR TITLE
fix(reddit): post get works with just ID, t3_ prefix, and includes parent_id

### DIFF
--- a/reddit/agent-harness/cli_web/reddit/commands/post.py
+++ b/reddit/agent-harness/cli_web/reddit/commands/post.py
@@ -23,14 +23,18 @@ def _parse_post_url(url_or_id: str) -> tuple[str, str, str]:
     Accepts:
       - Full URL: https://www.reddit.com/r/python/comments/abc123/my_post/
       - Short path: r/python/comments/abc123/my_post
-      - Just the post ID: abc123 (requires --sub option)
+      - Just the post ID: abc123 (subreddit resolved by Reddit API)
+      - Fullname: t3_abc123 (stripped to abc123)
     """
     # Full URL or path with /r/sub/comments/id/slug pattern
     match = re.search(r"r/([^/]+)/comments/([^/]+)(?:/([^/?]+))?", url_or_id)
     if match:
         return match.group(1), match.group(2), match.group(3) or ""
-    # Just an ID — caller must provide subreddit
-    return "", url_or_id.strip("/"), ""
+    # Strip t3_ prefix if present
+    post_id = url_or_id.strip("/")
+    if post_id.startswith("t3_"):
+        post_id = post_id[3:]
+    return "", post_id, ""
 
 
 @post.command("get")
@@ -50,9 +54,7 @@ def get(url_or_id, sub, comment_limit, use_json):
     use_json = resolve_json_mode(use_json)
     with handle_errors(json_mode=use_json):
         subreddit, post_id, slug = _parse_post_url(url_or_id)
-        if not subreddit:
-            if not sub:
-                raise click.UsageError("Provide a full URL or use --sub to specify the subreddit.")
+        if not subreddit and sub:
             subreddit = sub
 
         client = RedditClient()

--- a/reddit/agent-harness/cli_web/reddit/core/client.py
+++ b/reddit/agent-harness/cli_web/reddit/core/client.py
@@ -249,8 +249,15 @@ class RedditClient:
 
     def post_detail(self, subreddit: str, post_id: str, slug: str = "",
                     comment_limit: int = 50) -> list:
-        """Get post + comments. Returns [post_listing, comments_listing]."""
-        path = f"/r/{subreddit}/comments/{post_id}/{slug}.json"
+        """Get post + comments. Returns [post_listing, comments_listing].
+
+        If subreddit is empty, uses /comments/{id}.json which works without
+        knowing the subreddit (Reddit redirects internally).
+        """
+        if subreddit:
+            path = f"/r/{subreddit}/comments/{post_id}/{slug}.json"
+        else:
+            path = f"/comments/{post_id}.json"
         return self._get(path, params={"limit": comment_limit})
 
     # ── Authenticated: Me ────────────────────────────────────────

--- a/reddit/agent-harness/cli_web/reddit/core/models.py
+++ b/reddit/agent-harness/cli_web/reddit/core/models.py
@@ -72,6 +72,7 @@ def format_comment(child: dict) -> dict:
     d = child.get("data", child)
     return {
         "id": d.get("id", ""),
+        "parent_id": d.get("parent_id", ""),
         "author": d.get("author", "[deleted]"),
         "body": d.get("body", ""),
         "score": d.get("score", 0),


### PR DESCRIPTION
## Summary

- `post get <id>` now works without `--sub` flag — uses Reddit's `/comments/{id}.json` endpoint
- `post get t3_<id>` strips the `t3_` prefix automatically (fullname format support)
- Comments now include `parent_id` field for tracking reply trees

## Type of Change

- [x] **Bug Fix** -- fixes incorrect behavior

### For Existing CLI Modifications

- [x] No test regressions
- [x] Code follows existing patterns and conventions

## Before / After

```bash
# Before
cli-web-reddit post get 1s5cpno
→ Error: "Provide a full URL or use --sub to specify the subreddit."

# After
cli-web-reddit post get 1s5cpno
→ Returns post + comments (subreddit auto-resolved)

cli-web-reddit post get t3_1s5cpno
→ Also works (t3_ prefix stripped)
```

## Test Results

```
post get 1s5cpno → Title: "DAE close all their browser tabs..." / 15 comments ✓
post get t3_1s5cpno → Same result ✓
parent_id in comments → "t3_1s5cpno" for top-level, "t1_xxx" for nested ✓
```

Generated with [Claude Code](https://claude.com/claude-code)