### PR TITLE
refactor(plugin): extract shared utilities and add pytest coverage

### DIFF
--- a/cli-anything-web-plugin/HARNESS.md
+++ b/cli-anything-web-plugin/HARNESS.md
@@ -175,7 +175,7 @@ under `skills/*/references/` and are loaded when the relevant skill activates.
 
 | Script | Purpose | When to use |
 |--------|---------|-------------|
-| `phase-state.py` | Track all 4 pipeline phases — skip completed, retry failed | Before each phase, prevents re-running expensive work |
+| `phase-state.py` | Track all 4 pipeline phases — skip completed, retry failed. Low-level state store; mutated by skills via `complete`/`fail`/`reset`/`check`. | Before each phase, prevents re-running expensive work |
 | `capture-checkpoint.py` | Save/restore capture session state (within Phase 1) | Resume interrupted captures, prevent duplicate work |
 | `parse-trace.py` | Convert trace files → raw-traffic.json | After `tracing-stop` (default capture method) |
 | `mitmproxy-capture.py` | Optional proxy-based capture — no body truncation, real-time noise filtering, dedup, enhanced metadata (timestamps, cookies, body sizes). Supports `start-proxy`/`stop-proxy` for agent-driven browsing. Activated with `--mitmproxy` flag. Requires `pip install mitmproxy` (Python 3.12+). | When `--mitmproxy` flag is passed to `/cli-anything-web` |
@@ -189,12 +189,12 @@ under `skills/*/references/` and are loaded when the relevant skill activates.
 | Script | Purpose | When to use |
 |--------|---------|-------------|
 | `scaffold-cli.py` | Generate full boilerplate structure from templates (exceptions, client, config, auth, CLI entry, setup.py) | Phase 2 — Step B.0, before implementing endpoint methods |
-| `validate-checklist.py` | Run ~58 mechanical checks from the quality checklist (AST + regex) | Phase 4 — before manual review, or via `/validate` command |
+| `validate-checklist.py` | Run ~65 mechanical checks from the quality checklist (AST + regex) | Phase 4 — before manual review, or via `/validate` command |
 | `generate-test-docs.py` | AST-parse test files for TEST.md Part 1 (plan), run pytest for Part 2 (results) | Phase 3 — after writing tests |
 | `smoke-test.py` | Post-install CLI validation (--help, --version, --json, protocol leak detection) | Phase 4 — after `pip install -e .` |
 | `repl_skin.py` | Canonical REPL UI (banner, colors, help) — copied verbatim into every generated CLI's `utils/` | Phase 2 — copied by scaffold-cli.py |
 | `setup.sh` | One-time plugin setup — verifies dependencies (playwright, mitmproxy optional) | Plugin install / CI |
-| `run-pipeline.py` | Pipeline orchestrator — `status` view, `parse` (Phase 1 tail), `validate` (Phase 4 tail) | Any phase — `run-pipeline.py status <app-dir>` for next-action guidance |
+| `run-pipeline.py` | Pipeline orchestrator — `status` view (reads phase-state.json and adds next-action guidance), `parse` (Phase 1 tail), `validate` (Phase 4 tail). **Use this for human/agent-facing status**; use `phase-state.py` only to mutate state. | Any phase — `run-pipeline.py status <app-dir>` for next-action guidance |
 
 ### Shared Script Utilities (`scripts/`)
 
@@ -202,8 +202,8 @@ Sibling modules imported by multiple scripts — single source of truth.
 
 | Module | Exports | Consumers |
 |--------|---------|-----------|
-| `plugin_paths.py` | `get_plugin_root()`, `get_scripts_dir()`, `get_templates_dir()`, `get_skills_dir()`, `get_agents_dir()`, `get_commands_dir()` | scaffold-cli.py, run-pipeline.py |
-| `traffic_utils.py` | `NOISE_PATTERNS`, `STATIC_EXTENSIONS`, `is_noise_url()`, `is_static_asset()`, `normalize_headers()` | parse-trace.py, analyze-traffic.py, mitmproxy-capture.py |
+| `plugin_paths.py` | `get_plugin_root()`, `get_scripts_dir()`, `get_templates_dir()` | scaffold-cli.py, run-pipeline.py |
+| `traffic_utils.py` | `NOISE_PATTERNS`, `STATIC_EXTENSIONS`, `MEDIA_EXTENSIONS`, `is_noise_url()`, `is_static_asset(url, include_media=False)`, `normalize_headers()` | parse-trace.py, analyze-traffic.py, mitmproxy-capture.py |
 | `state_utils.py` | `utc_now_iso()`, `load_json_state()`, `save_json_state()` | phase-state.py, capture-checkpoint.py, run-pipeline.py |
 
 ### Pipeline Anatomy — Which Skill Calls Which Script

--- a/cli-anything-web-plugin/HARNESS.md
+++ b/cli-anything-web-plugin/HARNESS.md
@@ -192,6 +192,7 @@ under `skills/*/references/` and are loaded when the relevant skill activates.
 | `validate-checklist.py` | Run ~65 mechanical checks from the quality checklist (AST + regex) | Phase 4 — before manual review, or via `/validate` command |
 | `generate-test-docs.py` | AST-parse test files for TEST.md Part 1 (plan), run pytest for Part 2 (results) | Phase 3 — after writing tests |
 | `smoke-test.py` | Post-install CLI validation (--help, --version, --json, protocol leak detection) | Phase 4 — after `pip install -e .` |
+| `validate-capture.py` | Gate between Phase 1 and Phase 2 — checks entry count, protocol, WRITE ops, error rate, endpoint diversity | Phase 1 — end of Step 4 in capture skill |
 | `repl_skin.py` | Canonical REPL UI (banner, colors, help) — copied verbatim into every generated CLI's `utils/` | Phase 2 — copied by scaffold-cli.py |
 | `setup.sh` | One-time plugin setup — verifies dependencies (playwright, mitmproxy optional) | Plugin install / CI |
 | `run-pipeline.py` | Pipeline orchestrator — `status` view (reads phase-state.json and adds next-action guidance), `parse` (Phase 1 tail), `validate` (Phase 4 tail). **Use this for human/agent-facing status**; use `phase-state.py` only to mutate state. | Any phase — `run-pipeline.py status <app-dir>` for next-action guidance |

--- a/cli-anything-web-plugin/HARNESS.md
+++ b/cli-anything-web-plugin/HARNESS.md
@@ -181,6 +181,8 @@ under `skills/*/references/` and are loaded when the relevant skill activates.
 | `mitmproxy-capture.py` | Optional proxy-based capture — no body truncation, real-time noise filtering, dedup, enhanced metadata (timestamps, cookies, body sizes). Supports `start-proxy`/`stop-proxy` for agent-driven browsing. Activated with `--mitmproxy` flag. Requires `pip install mitmproxy` (Python 3.12+). | When `--mitmproxy` flag is passed to `/cli-anything-web` |
 | `analyze-traffic.py` | Analyze raw-traffic.json → protocol/endpoint detection. v1.3.0 adds request sequence, session lifecycle, and endpoint size analysis when enhanced fields are present. | Auto-run by parse-trace.py or mitmproxy-capture.py |
 | `extract-browser-cookies.py` | Cookie extraction utility | During auth implementation |
+| `site-fingerprint.js` | Playwright run-code script — detects SSR framework (Next.js, Nuxt, etc.) and baseline protections | Phase 1 — invoked by capture skill during site assessment |
+| `launch-chrome-debug.sh` | Launch Chrome with a dedicated debug profile + remote-debugging port | Phase 1 — when using `mcp__chrome-devtools__*` as fallback capture |
 
 ### Pipeline Automation Scripts (`scripts/`)
 
@@ -190,6 +192,29 @@ under `skills/*/references/` and are loaded when the relevant skill activates.
 | `validate-checklist.py` | Run ~58 mechanical checks from the quality checklist (AST + regex) | Phase 4 — before manual review, or via `/validate` command |
 | `generate-test-docs.py` | AST-parse test files for TEST.md Part 1 (plan), run pytest for Part 2 (results) | Phase 3 — after writing tests |
 | `smoke-test.py` | Post-install CLI validation (--help, --version, --json, protocol leak detection) | Phase 4 — after `pip install -e .` |
+| `repl_skin.py` | Canonical REPL UI (banner, colors, help) — copied verbatim into every generated CLI's `utils/` | Phase 2 — copied by scaffold-cli.py |
+| `setup.sh` | One-time plugin setup — verifies dependencies (playwright, mitmproxy optional) | Plugin install / CI |
+| `run-pipeline.py` | Pipeline orchestrator — `status` view, `parse` (Phase 1 tail), `validate` (Phase 4 tail) | Any phase — `run-pipeline.py status <app-dir>` for next-action guidance |
+
+### Shared Script Utilities (`scripts/`)
+
+Sibling modules imported by multiple scripts — single source of truth.
+
+| Module | Exports | Consumers |
+|--------|---------|-----------|
+| `plugin_paths.py` | `get_plugin_root()`, `get_scripts_dir()`, `get_templates_dir()`, `get_skills_dir()`, `get_agents_dir()`, `get_commands_dir()` | scaffold-cli.py, run-pipeline.py |
+| `traffic_utils.py` | `NOISE_PATTERNS`, `STATIC_EXTENSIONS`, `is_noise_url()`, `is_static_asset()`, `normalize_headers()` | parse-trace.py, analyze-traffic.py, mitmproxy-capture.py |
+| `state_utils.py` | `utc_now_iso()`, `load_json_state()`, `save_json_state()` | phase-state.py, capture-checkpoint.py, run-pipeline.py |
+
+### Pipeline Anatomy — Which Skill Calls Which Script
+
+| Phase | Skill | Primary scripts | Auxiliary scripts |
+|-------|-------|-----------------|-------------------|
+| 1. capture | `skills/capture/SKILL.md` | `site-fingerprint.js`, `parse-trace.py` (default) or `mitmproxy-capture.py` (--mitmproxy) | `capture-checkpoint.py` (resume), `launch-chrome-debug.sh` (fallback), `analyze-traffic.py` (auto-run by parse/mitmproxy) |
+| 2. methodology | `skills/methodology/SKILL.md` | `scaffold-cli.py` (Step B.0) | `repl_skin.py` (copied by scaffold-cli) |
+| 3. testing | `skills/testing/SKILL.md` | `generate-test-docs.py` (plan + results) | — |
+| 4. standards | `skills/standards/SKILL.md` | `validate-checklist.py`, `smoke-test.py` | 4 review agents in `agents/` (cross-cli-consistency, harness-compliance, output-ux, traffic-fidelity) |
+| any | — | `phase-state.py` (track), `run-pipeline.py status` (next action) | — |
 
 ### Methodology References (`skills/methodology/references/`)
 

--- a/cli-anything-web-plugin/scripts/analyze-traffic.py
+++ b/cli-anything-web-plugin/scripts/analyze-traffic.py
@@ -33,55 +33,13 @@ from collections import Counter, defaultdict
 from pathlib import Path
 from urllib.parse import urlparse, parse_qs, unquote
 
+# Ensure sibling modules resolve whether invoked as a script or via importlib.
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
 
-def _normalize_headers(headers) -> dict:
-    """Normalize headers to dict format.
-
-    Playwright traces may use [{name, value}] arrays while mitmproxy uses
-    flat dicts. This function accepts both and returns a flat dict.
-    """
-    if isinstance(headers, dict):
-        return headers
-    if isinstance(headers, list):
-        return {h.get("name", ""): h.get("value", "") for h in headers if isinstance(h, dict)}
-    return {}
-
-
-def _is_noise_url(url: str) -> bool:
-    """Check if a URL is analytics/tracking/CDN noise — not a real API call."""
-    NOISE = [
-        # Google analytics / ads
-        "google-analytics", "analytics.google.com", "googletagmanager.com",
-        "googlesyndication", "google.com/ads", "google.com/pagead",
-        "doubleclick.net", "www.google.co.", "gstatic.com",
-        "googleapis.com/css", "fonts.googleapis.com",
-        "play.google.com/log", "signaler-pa.clients6",
-        "accounts.google.com/gsi", "apis.google.com",
-        # Cloudflare
-        "cdn-cgi/", "cloudflareinsights", "static.cloudflareinsights",
-        # Social / ad networks
-        "facebook.com/tr", "facebook.net",
-        "twitter.com", "analytics.twitter.com",
-        "taboola.com", "optable.co", "admedo.com",
-        "scorecardresearch.com", "statcounter.com",
-        "liftdsp.com", "bidr.io", "cnv.event.prod",
-        # Monitoring / analytics SDKs
-        "datadoghq.com", "browser-intake-datadoghq",
-        "fullstory.com", "segment.prod",
-        # CRM / marketing automation
-        "hubspot.com", "hscollectedforms.net", "hsforms.com",
-        "cookiebot.com",
-        # Generic tracking patterns (same-site endpoints)
-        "/ht/event", "/hubspot",
-        # GitHub internal
-        "avatars.githubusercontent.com", "collector.github.com",
-        "api.github.com/_private",
-        # Generic noise patterns
-        "/manifest.json", "/beacon", "/pixel", "/rum",
-        "slinksuggestion.com", "drainpaste.com",
-        "e.producthunt.com", "t.producthunt.com",
-    ]
-    return any(x in url for x in NOISE)
+from traffic_utils import is_noise_url as _is_noise_url  # noqa: E402
+from traffic_utils import normalize_headers as _normalize_headers  # noqa: E402
 
 
 def _detect_ws_library(url: str) -> str | None:

--- a/cli-anything-web-plugin/scripts/analyze-traffic.py
+++ b/cli-anything-web-plugin/scripts/analyze-traffic.py
@@ -105,7 +105,7 @@ def detect_protocol(entries: list[dict]) -> dict:
     firebase_paths = []
 
     for e in entries:
-        url = e.get("url", "")
+        url = (e.get("url") or "")
         method = e.get("method", "GET")
         mime = e.get("mime_type", "")
         body = e.get("post_data", "") or ""
@@ -357,7 +357,7 @@ def detect_auth(entries: list[dict]) -> dict:
     api_key_headers = set()
     cookie_names = set()
 
-    for e in (e for e in entries if not _is_noise_url(e.get("url", ""))):
+    for e in (e for e in entries if not _is_noise_url((e.get("url") or ""))):
         headers = _normalize_headers(e.get("request_headers", {}))
         has_auth = False
 
@@ -391,7 +391,7 @@ def detect_auth(entries: list[dict]) -> dict:
 
     # Use actual count of non-noise entries as denominator (a request may have
     # both bearer and cookie, so summing individual counters would inflate total)
-    total = sum(1 for _ in (e for e in entries if not _is_noise_url(e.get("url", "")))) or 1
+    total = sum(1 for _ in (e for e in entries if not _is_noise_url((e.get("url") or "")))) or 1
     patterns = {}
     if bearer_count > 0:
         patterns["bearer"] = round(bearer_count / total * 100, 1)
@@ -551,10 +551,10 @@ _STATIC_EXTENSIONS = (
 
 def _is_static_asset(entry: dict) -> bool:
     """Return True if the entry is a static asset (image, font, CSS, JS)."""
-    mime = entry.get("mime_type", "").split(";")[0].strip().lower()
+    mime = (entry.get("mime_type") or "").split(";")[0].strip().lower()
     if any(mime.startswith(p) for p in _STATIC_MIME_PREFIXES):
         return True
-    url = entry.get("url", "").split("?")[0].lower()
+    url = (entry.get("url") or "").split("?")[0].lower()
     if any(url.endswith(ext) for ext in _STATIC_EXTENSIONS):
         return True
     return False
@@ -564,14 +564,14 @@ def group_endpoints(entries: list[dict]) -> list[dict]:
     """Group API requests by URL prefix into resource groups."""
     api_entries = [
         e for e in entries
-        if not _is_noise_url(e.get("url", "")) and not _is_static_asset(e)
+        if not _is_noise_url((e.get("url") or "")) and not _is_static_asset(e)
     ]
 
     # Parse URLs and group by prefix
     groups = defaultdict(lambda: {"methods": Counter(), "urls": set(), "count": 0})
 
     for e in api_entries:
-        url = e.get("url", "")
+        url = (e.get("url") or "")
         method = e.get("method", "GET")
         parsed = urlparse(url)
 
@@ -623,7 +623,7 @@ def detect_pagination(entries: list[dict]) -> dict:
     paginated_endpoints = {}  # prefix → set of pagination params seen
 
     for e in entries:
-        url = e.get("url", "")
+        url = (e.get("url") or "")
         if _is_noise_url(url):
             continue
         parsed = urlparse(url)
@@ -681,7 +681,7 @@ def detect_rate_limits(entries: list[dict]) -> dict:
 
 def compute_stats(entries: list[dict]) -> dict:
     """Compute basic traffic statistics. Noise URLs excluded from method/status/MIME counts; domains include all entries."""
-    api_entries = [e for e in entries if not _is_noise_url(e.get("url", ""))]
+    api_entries = [e for e in entries if not _is_noise_url((e.get("url") or ""))]
 
     methods = Counter(e.get("method", "GET") for e in api_entries)
     statuses = Counter(e.get("status", 0) for e in api_entries)
@@ -693,7 +693,7 @@ def compute_stats(entries: list[dict]) -> dict:
     # Unique domains (from all entries, including noise — useful for awareness)
     domains = set()
     for e in entries:
-        parsed = urlparse(e.get("url", ""))
+        parsed = urlparse((e.get("url") or ""))
         if parsed.hostname:
             domains.add(parsed.hostname)
 
@@ -799,7 +799,7 @@ def detect_request_sequence(entries: list[dict]) -> dict:
     for i, e in enumerate(timed[:20]):
         ts = _ts(e) or 0
         delta_ms = round((ts - prev_ts) * 1000, 1) if i > 0 else 0
-        url = e.get("url", "")
+        url = (e.get("url") or "")
         timeline.append({
             "seq": i + 1,
             "method": e.get("method", "GET"),
@@ -816,7 +816,7 @@ def detect_request_sequence(entries: list[dict]) -> dict:
 
     for i, e in enumerate(timed):
         seq = i + 1
-        url = e.get("url", "")
+        url = (e.get("url") or "")
         method = e.get("method", "GET")
         status = e.get("status", 0)
         resp_cookies = e.get("response_cookies", []) or []
@@ -861,11 +861,11 @@ def detect_request_sequence(entries: list[dict]) -> dict:
     # Build a map of URL → entry for redirect target matching
     url_to_entry = {}
     for e in timed:
-        url_to_entry.setdefault(e.get("url", ""), e)
+        url_to_entry.setdefault((e.get("url") or ""), e)
 
     visited_redirects: set[str] = set()
     for e in timed:
-        url = e.get("url", "")
+        url = (e.get("url") or "")
         status = e.get("status", 0)
         if status not in (301, 302, 303, 307, 308):
             continue
@@ -925,7 +925,7 @@ def detect_session_lifecycle(entries: list[dict]) -> dict:
     seen_set = set()  # dedupe (name, domain) for cookies_set list
 
     for e in entries:
-        url = e.get("url", "")
+        url = (e.get("url") or "")
         parsed = urlparse(url)
         domain = parsed.hostname or ""
 
@@ -999,7 +999,7 @@ def classify_endpoints_by_size(entries: list[dict]) -> dict:
         if size is None:
             continue
 
-        url = e.get("url", "")
+        url = (e.get("url") or "")
         if _is_noise_url(url) or _is_static_asset(e):
             continue
 

--- a/cli-anything-web-plugin/scripts/capture-checkpoint.py
+++ b/cli-anything-web-plugin/scripts/capture-checkpoint.py
@@ -23,8 +23,14 @@ Usage:
 import argparse
 import json
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
+
+# Ensure sibling modules resolve whether invoked as a script or via importlib.
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from state_utils import load_json_state, save_json_state, utc_now_iso  # noqa: E402
 
 CHECKPOINT_FILE = ".capture-state.json"
 
@@ -45,19 +51,12 @@ def _checkpoint_path(app_dir: str) -> Path:
 
 
 def _load(app_dir: str) -> dict | None:
-    p = _checkpoint_path(app_dir)
-    if not p.exists():
-        return None
-    with open(p, "r", encoding="utf-8") as f:
-        return json.load(f)
+    return load_json_state(_checkpoint_path(app_dir), default=None)
 
 
 def _save(app_dir: str, state: dict) -> None:
     p = _checkpoint_path(app_dir)
-    p.parent.mkdir(parents=True, exist_ok=True)
-    state["updated_at"] = datetime.now(timezone.utc).isoformat()
-    with open(p, "w", encoding="utf-8") as f:
-        json.dump(state, f, indent=2, ensure_ascii=False)
+    save_json_state(p, state)
     print(f"Checkpoint saved: {p}")
 
 
@@ -66,7 +65,7 @@ def cmd_save(args: argparse.Namespace) -> None:
     state = {
         "app_dir": str(Path(args.app_dir).resolve()),
         "step": args.step or existing.get("step", "setup"),
-        "created_at": existing.get("created_at", datetime.now(timezone.utc).isoformat()),
+        "created_at": existing.get("created_at", utc_now_iso()),
         "session_name": args.session or existing.get("session_name"),
         "url": args.url or existing.get("url"),
         "auth_saved": args.auth_saved or existing.get("auth_saved", False),
@@ -84,7 +83,7 @@ def cmd_save(args: argparse.Namespace) -> None:
             "id": args.trace_id,
             "status": args.trace_status or "active",
             "purpose": args.trace_purpose or "capture",
-            "started_at": datetime.now(timezone.utc).isoformat(),
+            "started_at": utc_now_iso(),
         }
         # Update existing trace or add new
         updated = False

--- a/cli-anything-web-plugin/scripts/mitmproxy-capture.py
+++ b/cli-anything-web-plugin/scripts/mitmproxy-capture.py
@@ -58,7 +58,12 @@ if _SCRIPT_DIR not in sys.path:
 
 from traffic_utils import NOISE_PATTERNS, STATIC_EXTENSIONS  # noqa: E402,F401
 from traffic_utils import is_noise_url as _is_noise  # noqa: E402
-from traffic_utils import is_static_asset as _is_static  # noqa: E402
+from traffic_utils import is_static_asset  # noqa: E402
+
+
+def _is_static(url: str) -> bool:
+    """Real-time capture: include media extensions (preserves pre-refactor behavior)."""
+    return is_static_asset(url, include_media=True)
 
 
 # ---------------------------------------------------------------------------

--- a/cli-anything-web-plugin/scripts/mitmproxy-capture.py
+++ b/cli-anything-web-plugin/scripts/mitmproxy-capture.py
@@ -31,7 +31,6 @@ import argparse
 import asyncio
 import json
 import os
-import re
 import signal
 import subprocess
 import sys
@@ -52,88 +51,14 @@ from mitmproxy.tools.dump import DumpMaster  # noqa: E402
 # Constants
 # ---------------------------------------------------------------------------
 
-STATIC_EXTENSIONS = frozenset((
-    ".js", ".css", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico",
-    ".woff", ".woff2", ".ttf", ".eot", ".map", ".webp", ".avif",
-    ".mp4", ".webm", ".mp3", ".ogg",
-))
+# Ensure sibling modules resolve whether invoked as a script or via importlib.
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
 
-# Noise URL patterns — analytics, tracking, ad networks.
-# Filtered in real-time during capture (not post-hoc).
-NOISE_PATTERNS = [
-    re.compile(r"google-analytics\.com", re.I),
-    re.compile(r"googletagmanager\.com", re.I),
-    re.compile(r"googlesyndication\.com", re.I),
-    re.compile(r"googleadservices\.com", re.I),
-    re.compile(r"doubleclick\.net", re.I),
-    re.compile(r"google\.com/pagead", re.I),
-    re.compile(r"facebook\.net", re.I),
-    re.compile(r"facebook\.com/tr", re.I),
-    re.compile(r"connect\.facebook", re.I),
-    re.compile(r"analytics\.twitter\.com", re.I),
-    re.compile(r"ads-twitter\.com", re.I),
-    re.compile(r"taboola\.com", re.I),
-    re.compile(r"outbrain\.com", re.I),
-    re.compile(r"segment\.io", re.I),
-    re.compile(r"segment\.com/v1", re.I),
-    re.compile(r"amplitude\.com", re.I),
-    re.compile(r"mixpanel\.com", re.I),
-    re.compile(r"hotjar\.com", re.I),
-    re.compile(r"clarity\.ms", re.I),
-    re.compile(r"sentry\.io/api", re.I),
-    re.compile(r"datadoghq\.com", re.I),
-    re.compile(r"rum-http-intake", re.I),
-    re.compile(r"browser-intake-datadoghq", re.I),
-    re.compile(r"hubspot\.com", re.I),
-    re.compile(r"intercom\.io", re.I),
-    re.compile(r"crisp\.chat", re.I),
-    re.compile(r"zendesk\.com", re.I),
-    re.compile(r"newrelic\.com", re.I),
-    re.compile(r"nr-data\.net", re.I),
-    re.compile(r"fontawesome\.com", re.I),
-    re.compile(r"fonts\.googleapis\.com", re.I),
-    re.compile(r"fonts\.gstatic\.com", re.I),
-    re.compile(r"/beacon", re.I),
-    re.compile(r"/pixel", re.I),
-    re.compile(r"/collect\b", re.I),
-    re.compile(r"accounts\.google\.com/gsi/", re.I),
-    re.compile(r"cdn-cgi/rum", re.I),
-    re.compile(r"cdn-cgi/challenge-platform", re.I),
-    # Ad networks / programmatic advertising
-    re.compile(r"rubiconproject\.com", re.I),
-    re.compile(r"criteo\.com", re.I),
-    re.compile(r"adnxs\.com", re.I),
-    re.compile(r"adsrvr\.org", re.I),
-    re.compile(r"sharethrough\.com", re.I),
-    re.compile(r"3lift\.com", re.I),
-    re.compile(r"liadm\.com", re.I),
-    re.compile(r"bidr\.io", re.I),
-    re.compile(r"id5-sync\.com", re.I),
-    re.compile(r"casalemedia\.com", re.I),
-    re.compile(r"kargo\.com", re.I),
-    re.compile(r"unrulymedia\.com", re.I),
-    re.compile(r"lngtd\.com", re.I),
-    re.compile(r"creativecdn\.com", re.I),
-    re.compile(r"cookielaw\.org", re.I),
-    re.compile(r"onetrust\.com", re.I),
-    re.compile(r"adtrafficquality\.google", re.I),
-    re.compile(r"hadron\.ad\.gt", re.I),
-    re.compile(r"googlesyndication", re.I),
-    re.compile(r"moatads\.com", re.I),
-    re.compile(r"amazon-adsystem\.com", re.I),
-    re.compile(r"pubmatic\.com", re.I),
-    re.compile(r"openx\.net", re.I),
-    re.compile(r"indexww\.com", re.I),
-]
-
-
-def _is_noise(url: str) -> bool:
-    return any(p.search(url) for p in NOISE_PATTERNS)
-
-
-def _is_static(url: str) -> bool:
-    path = url.split("?")[0].split("#")[0]
-    return any(path.endswith(ext) for ext in STATIC_EXTENSIONS)
+from traffic_utils import NOISE_PATTERNS, STATIC_EXTENSIONS  # noqa: E402,F401
+from traffic_utils import is_noise_url as _is_noise  # noqa: E402
+from traffic_utils import is_static_asset as _is_static  # noqa: E402
 
 
 # ---------------------------------------------------------------------------

--- a/cli-anything-web-plugin/scripts/parse-trace.py
+++ b/cli-anything-web-plugin/scripts/parse-trace.py
@@ -15,11 +15,12 @@ import json
 import sys
 from pathlib import Path
 
+# Ensure sibling modules resolve whether invoked as a script or via importlib.
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
 
-STATIC_EXTENSIONS = (
-    ".js", ".css", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico",
-    ".woff", ".woff2", ".ttf", ".eot", ".map", ".webp", ".avif",
-)
+from traffic_utils import STATIC_EXTENSIONS, is_static_asset  # noqa: E402
 
 
 def parse_network_file(network_path: Path, resources_dir: Path, filter_static: bool = True) -> list[dict]:
@@ -46,10 +47,8 @@ def parse_network_file(network_path: Path, resources_dir: Path, filter_static: b
         url = req.get("url", "")
 
         # Filter static assets
-        if filter_static:
-            url_path = url.split("?")[0].split("#")[0]
-            if any(url_path.endswith(ext) for ext in STATIC_EXTENSIONS):
-                continue
+        if filter_static and is_static_asset(url):
+            continue
 
         # Load response body from resources/
         body = None

--- a/cli-anything-web-plugin/scripts/phase-state.py
+++ b/cli-anything-web-plugin/scripts/phase-state.py
@@ -28,8 +28,14 @@ Usage:
 import argparse
 import json
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
+
+# Ensure sibling modules resolve whether invoked as a script or via importlib.
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from state_utils import load_json_state, save_json_state, utc_now_iso  # noqa: E402
 
 STATE_FILE = "phase-state.json"
 PHASES = ["capture", "methodology", "testing", "standards"]
@@ -40,23 +46,16 @@ def _state_path(app_dir: str) -> Path:
 
 
 def _load(app_dir: str) -> dict:
-    p = _state_path(app_dir)
-    if not p.exists():
-        return {
-            "app_dir": str(Path(app_dir).resolve()),
-            "created_at": datetime.now(timezone.utc).isoformat(),
-            "phases": {phase: {"status": "pending"} for phase in PHASES},
-        }
-    with open(p, "r", encoding="utf-8") as f:
-        return json.load(f)
+    default = {
+        "app_dir": str(Path(app_dir).resolve()),
+        "created_at": utc_now_iso(),
+        "phases": {phase: {"status": "pending"} for phase in PHASES},
+    }
+    return load_json_state(_state_path(app_dir), default=default)
 
 
 def _save(app_dir: str, state: dict) -> None:
-    p = _state_path(app_dir)
-    p.parent.mkdir(parents=True, exist_ok=True)
-    state["updated_at"] = datetime.now(timezone.utc).isoformat()
-    with open(p, "w", encoding="utf-8") as f:
-        json.dump(state, f, indent=2, ensure_ascii=False)
+    save_json_state(_state_path(app_dir), state)
 
 
 def cmd_status(args: argparse.Namespace) -> None:
@@ -99,7 +98,7 @@ def cmd_complete(args: argparse.Namespace) -> None:
     state = _load(args.app_dir)
     state["phases"][args.phase] = {
         "status": "done",
-        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "completed_at": utc_now_iso(),
         "output": args.output,
         "notes": args.notes,
     }
@@ -111,7 +110,7 @@ def cmd_fail(args: argparse.Namespace) -> None:
     state = _load(args.app_dir)
     state["phases"][args.phase] = {
         "status": "failed",
-        "failed_at": datetime.now(timezone.utc).isoformat(),
+        "failed_at": utc_now_iso(),
         "error": args.error,
         "error_type": args.error_type or "unknown",
     }

--- a/cli-anything-web-plugin/scripts/plugin_paths.py
+++ b/cli-anything-web-plugin/scripts/plugin_paths.py
@@ -1,0 +1,45 @@
+"""Canonical path discovery for cli-anything-web-plugin scripts.
+
+Every script that needs to locate plugin resources (templates, other scripts,
+skills, etc.) should import from this module instead of re-deriving paths
+relative to `__file__`. This is the single source of truth — if the plugin
+directory layout changes, only this file updates.
+
+Usage:
+    from plugin_paths import get_plugin_root, get_templates_dir
+
+    tpl = get_templates_dir() / "exceptions.py.tpl"
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def get_plugin_root() -> Path:
+    """Return the cli-anything-web-plugin directory (parent of scripts/)."""
+    return Path(__file__).resolve().parent.parent
+
+
+def get_scripts_dir() -> Path:
+    """Return the scripts/ directory."""
+    return get_plugin_root() / "scripts"
+
+
+def get_templates_dir() -> Path:
+    """Return the templates/ directory."""
+    return get_plugin_root() / "templates"
+
+
+def get_skills_dir() -> Path:
+    """Return the skills/ directory."""
+    return get_plugin_root() / "skills"
+
+
+def get_agents_dir() -> Path:
+    """Return the agents/ directory."""
+    return get_plugin_root() / "agents"
+
+
+def get_commands_dir() -> Path:
+    """Return the commands/ directory."""
+    return get_plugin_root() / "commands"

--- a/cli-anything-web-plugin/scripts/plugin_paths.py
+++ b/cli-anything-web-plugin/scripts/plugin_paths.py
@@ -28,18 +28,3 @@ def get_scripts_dir() -> Path:
 def get_templates_dir() -> Path:
     """Return the templates/ directory."""
     return get_plugin_root() / "templates"
-
-
-def get_skills_dir() -> Path:
-    """Return the skills/ directory."""
-    return get_plugin_root() / "skills"
-
-
-def get_agents_dir() -> Path:
-    """Return the agents/ directory."""
-    return get_plugin_root() / "agents"
-
-
-def get_commands_dir() -> Path:
-    """Return the commands/ directory."""
-    return get_plugin_root() / "commands"

--- a/cli-anything-web-plugin/scripts/run-pipeline.py
+++ b/cli-anything-web-plugin/scripts/run-pipeline.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Pipeline orchestrator — one-stop status and next-action guidance.
+
+The 4-phase pipeline (capture → methodology → testing → standards) is executed
+by skills invoked inside Claude Code. This orchestrator does NOT run the skills
+itself; instead, it reads the current pipeline state and prints:
+
+1. The per-phase status (pending / in-progress / done / failed)
+2. The current phase and the script/skill that advances it
+3. Copy-paste commands for the next action
+
+It also exposes two fully-automated sub-phases that don't need a Claude turn:
+- `parse` runs parse-trace.py → analyze-traffic.py on a traces directory
+- `validate` runs validate-checklist.py + smoke-test.py
+
+Usage:
+    # Show full pipeline status + next action
+    python run-pipeline.py status <app-dir>
+
+    # Run the scriptable parse step (Phase 1 tail)
+    python run-pipeline.py parse <app-dir> --traces-dir .playwright-cli/traces/
+
+    # Run the scriptable validation step (Phase 4 tail)
+    python run-pipeline.py validate <app-dir> --cli-name cli-web-foo
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from plugin_paths import get_scripts_dir  # noqa: E402
+from state_utils import load_json_state  # noqa: E402
+
+PHASES = ["capture", "methodology", "testing", "standards"]
+
+# Human-readable next-action guidance per phase. Skills are the primary
+# execution units; scripts are scriptable sub-steps.
+_NEXT_ACTION = {
+    "capture": {
+        "skill": "capture",
+        "script": "parse-trace.py / analyze-traffic.py",
+        "how": "Invoke the capture skill, then `run-pipeline.py parse`",
+    },
+    "methodology": {
+        "skill": "methodology",
+        "script": "scaffold-cli.py",
+        "how": "Invoke the methodology skill (it calls scaffold-cli.py)",
+    },
+    "testing": {
+        "skill": "testing",
+        "script": "generate-test-docs.py",
+        "how": "Invoke the testing skill (it calls generate-test-docs.py)",
+    },
+    "standards": {
+        "skill": "standards",
+        "script": "validate-checklist.py / smoke-test.py",
+        "how": "Invoke the standards skill, then `run-pipeline.py validate`",
+    },
+}
+
+
+def _read_phase_state(app_dir: Path) -> dict:
+    """Load phase-state.json if present; return a pending-default shape otherwise."""
+    state_file = app_dir / "phase-state.json"
+    default = {"phases": {p: {"status": "pending"} for p in PHASES}}
+    return load_json_state(state_file, default=default)
+
+
+def _first_incomplete_phase(phases: dict) -> str | None:
+    """Return the first phase that is not `done`, or None if all are done."""
+    for phase in PHASES:
+        if phases.get(phase, {}).get("status") != "done":
+            return phase
+    return None
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    app_dir = Path(args.app_dir).resolve()
+    state = _read_phase_state(app_dir)
+    phases = state.get("phases", {})
+    current = _first_incomplete_phase(phases)
+
+    report = {
+        "app_dir": str(app_dir),
+        "phases": {p: phases.get(p, {"status": "pending"}) for p in PHASES},
+        "current_phase": current,
+        "next_action": None,
+    }
+
+    if current is None:
+        report["next_action"] = {
+            "summary": "Pipeline complete — all 4 phases done.",
+            "skill": None,
+            "script": None,
+        }
+    else:
+        info = dict(_NEXT_ACTION[current])
+        info["summary"] = f"Run the {current} phase."
+        report["next_action"] = info
+
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+
+
+def _run(cmd: list[str]) -> int:
+    """Run a subprocess, stream its output, return exit code."""
+    print(f"$ {' '.join(cmd)}", file=sys.stderr)
+    return subprocess.call(cmd)
+
+
+def cmd_parse(args: argparse.Namespace) -> None:
+    """Scriptable Phase-1 tail: parse traces → raw-traffic.json + analysis."""
+    scripts = get_scripts_dir()
+    output = Path(args.app_dir) / "traffic-capture" / "raw-traffic.json"
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    rc = _run([
+        sys.executable, str(scripts / "parse-trace.py"),
+        args.traces_dir,
+        "--output", str(output),
+    ])
+    if rc != 0:
+        sys.exit(rc)
+
+    # parse-trace.py auto-invokes analyze-traffic.py when possible;
+    # no separate call needed.
+    print(f"\nDone. Raw traffic: {output}")
+    print(f"Analysis: {output.parent / 'traffic-analysis.json'}")
+
+
+def cmd_validate(args: argparse.Namespace) -> None:
+    """Scriptable Phase-4 tail: validate-checklist + smoke-test."""
+    scripts = get_scripts_dir()
+    app_dir = Path(args.app_dir).resolve()
+
+    rc = _run([
+        sys.executable, str(scripts / "validate-checklist.py"),
+        str(app_dir),
+    ])
+    if rc != 0 and not args.keep_going:
+        sys.exit(rc)
+
+    if args.cli_name:
+        rc = _run([
+            sys.executable, str(scripts / "smoke-test.py"),
+            args.cli_name,
+        ])
+        if rc != 0 and not args.keep_going:
+            sys.exit(rc)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Pipeline orchestrator — status view + scriptable sub-steps."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_status = sub.add_parser("status", help="Show pipeline state + next action")
+    p_status.add_argument("app_dir", help="App directory (e.g., hackernews)")
+    p_status.set_defaults(func=cmd_status)
+
+    p_parse = sub.add_parser("parse", help="Run parse-trace.py + analyze-traffic.py")
+    p_parse.add_argument("app_dir", help="App directory")
+    p_parse.add_argument(
+        "--traces-dir",
+        required=True,
+        help="Path to .playwright-cli/traces/ directory",
+    )
+    p_parse.set_defaults(func=cmd_parse)
+
+    p_validate = sub.add_parser("validate", help="Run validate-checklist.py + smoke-test.py")
+    p_validate.add_argument("app_dir", help="App directory")
+    p_validate.add_argument(
+        "--cli-name",
+        help="CLI binary name (e.g. cli-web-foo); required for smoke-test",
+    )
+    p_validate.add_argument(
+        "--keep-going",
+        action="store_true",
+        help="Don't stop on first failure",
+    )
+    p_validate.set_defaults(func=cmd_validate)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/cli-anything-web-plugin/scripts/scaffold-cli.py
+++ b/cli-anything-web-plugin/scripts/scaffold-cli.py
@@ -28,10 +28,16 @@ import shutil
 import sys
 from pathlib import Path
 
-# Resolve template dir relative to this script
-SCRIPT_DIR = Path(__file__).resolve().parent
-PLUGIN_DIR = SCRIPT_DIR.parent
-TEMPLATES_DIR = PLUGIN_DIR / "templates"
+# Ensure sibling modules resolve whether invoked as a script or via importlib.
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from plugin_paths import get_plugin_root, get_scripts_dir, get_templates_dir  # noqa: E402
+
+SCRIPT_DIR = get_scripts_dir()
+PLUGIN_DIR = get_plugin_root()
+TEMPLATES_DIR = get_templates_dir()
 
 
 # ---------------------------------------------------------------------------
@@ -70,19 +76,54 @@ def to_underscore(name: str) -> str:
     return name.replace("-", "_")
 
 
-def render_template(tpl_path: Path, variables: dict) -> str:
-    """Read a .tpl file and substitute $-variables."""
-    content = tpl_path.read_text(encoding="utf-8")
-    # Use Template for safe substitution (ignores unknown $vars in code)
-    # We need to be careful: Python code has $ in f-strings etc.
-    # Use a custom approach: only replace our known placeholders
+# Matches ${Name}, ${name_thing}, ${APP_NAME}. Python f-strings use {name} (no $),
+# so this only catches genuine template placeholders.
+_PLACEHOLDER_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def render_string(content: str, variables: dict[str, str]) -> str:
+    """Substitute ${name} placeholders in a string."""
     for key, value in variables.items():
         content = content.replace(f"${{{key}}}", value)
     return content
 
 
+def find_unresolved_placeholders(content: str) -> list[str]:
+    """Return list of any ${...} placeholders still present in rendered output."""
+    return sorted(set(_PLACEHOLDER_RE.findall(content)))
+
+
+def render_template(tpl_path: Path, variables: dict[str, str]) -> str:
+    """Read a .tpl file, substitute ${name} placeholders, and validate.
+
+    Raises ValueError if the rendered output still contains unresolved ${name}
+    placeholders — this catches typos and newly-added template vars that weren't
+    wired into the variables dict.
+    """
+    content = tpl_path.read_text(encoding="utf-8")
+    rendered = render_string(content, variables)
+    unresolved = find_unresolved_placeholders(rendered)
+    if unresolved:
+        raise ValueError(
+            f"Template {tpl_path.name} has unresolved placeholders after render: "
+            f"{', '.join('${' + p + '}' for p in unresolved)}. "
+            f"Add them to the variables dict or fix the template."
+        )
+    return rendered
+
+
 def write_file(path: Path, content: str) -> None:
-    """Write content to a file, creating parent dirs."""
+    """Write content to a file, creating parent dirs.
+
+    Validates that no ${name} placeholders remain — protects against fragments
+    built without render_template (e.g., build_client's injected methods).
+    """
+    unresolved = find_unresolved_placeholders(content)
+    if unresolved:
+        raise ValueError(
+            f"Refusing to write {path}: unresolved placeholders "
+            f"{', '.join('${' + p + '}' for p in unresolved)}"
+        )
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
     print(f"  Created: {path}")
@@ -134,10 +175,11 @@ def build_client(variables: dict, protocol: str, http_client: str) -> str:
         return data.get("data", data)
 
 '''
-        # Replace the placeholder with the actual variable
-        extra_methods = extra_methods.replace("${AppName}", variables["AppName"])
 
     if extra_methods:
+        # Route injected methods through the same substitution pipeline so any
+        # ${placeholder} resolves consistently and write_file's validator runs.
+        extra_methods = render_string(extra_methods, variables)
         content = content.replace(
             "    def close(self):",
             extra_methods + "    def close(self):",

--- a/cli-anything-web-plugin/scripts/scaffold-cli.py
+++ b/cli-anything-web-plugin/scripts/scaffold-cli.py
@@ -180,156 +180,44 @@ def build_client(variables: dict, protocol: str, http_client: str) -> str:
         # Route injected methods through the same substitution pipeline so any
         # ${placeholder} resolves consistently and write_file's validator runs.
         extra_methods = render_string(extra_methods, variables)
-        content = content.replace(
-            "    def close(self):",
-            extra_methods + "    def close(self):",
-        )
+        anchor = "    def close(self):"
+        if anchor not in content:
+            raise ValueError(
+                f"Base client template {base_tpl!r} is missing required anchor "
+                f"{anchor!r} — protocol={protocol} injection would be silently "
+                f"dropped. If you renamed close(), update build_client()."
+            )
+        content = content.replace(anchor, extra_methods + anchor)
 
     return content
-
-
-# ---------------------------------------------------------------------------
-# Config template selection
-# ---------------------------------------------------------------------------
-
-def build_config(variables: dict, auth_type: str, has_context: bool) -> str:
-    """Generate config.py with conditional auth/context sections."""
-    has_auth = auth_type != "none"
-    lines = [
-        f'"""Configuration constants for cli-web-{variables["app_name"]}."""',
-        "from pathlib import Path",
-        "",
-        f'APP_NAME = "cli-web-{variables["app_name"]}"',
-        "CONFIG_DIR = Path.home() / \".config\" / APP_NAME",
-    ]
-    if has_auth:
-        lines.append('AUTH_FILE = "auth.json"')
-        lines.append(f'AUTH_ENV_VAR = "CLI_WEB_{variables["APP_NAME"]}_AUTH_JSON"')
-    if has_context:
-        lines.append('CONTEXT_FILE = "context.json"')
-    lines.extend([
-        "",
-        "",
-        "def get_config_dir() -> Path:",
-        '    """Return (and create) the config directory."""',
-        "    CONFIG_DIR.mkdir(parents=True, exist_ok=True)",
-        "    return CONFIG_DIR",
-    ])
-    if has_auth:
-        lines.extend([
-            "",
-            "",
-            "def get_auth_path() -> Path:",
-            '    """Return the path to auth.json, creating config dir if needed."""',
-            "    return get_config_dir() / AUTH_FILE",
-        ])
-    lines.append("")
-    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
 # Helpers.py conditional sections
 # ---------------------------------------------------------------------------
 
+# Each feature flag maps to a fragment template under templates/. Fragments
+# are rendered via the normal template pipeline (validated for unresolved
+# placeholders, no f-string quote hazards). Add a new flag by creating a
+# `helpers_<flag>.py.tpl` file and registering it here.
+_HELPER_FRAGMENTS = [
+    ("has_partial_ids", "helpers_partial_ids.py.tpl"),
+    ("has_polling", "helpers_polling.py.tpl"),
+    ("has_context", "helpers_context.py.tpl"),
+]
+
+
 def build_helpers(variables: dict, has_polling: bool, has_context: bool, has_partial_ids: bool) -> str:
-    """Render helpers.py with conditional sections included/excluded."""
+    """Render helpers.py by composing the base template with feature fragments."""
+    flags = {
+        "has_partial_ids": has_partial_ids,
+        "has_polling": has_polling,
+        "has_context": has_context,
+    }
     content = render_template(TEMPLATES_DIR / "helpers.py.tpl", variables)
-
-    # Add conditional sections
-    sections = []
-
-    if has_partial_ids:
-        sections.append(f'''
-
-def resolve_partial_id(partial: str, items: list[dict], key: str = "id") -> dict:
-    """Resolve a partial ID prefix to a single item.
-
-    Raises {variables["AppName"]}Error if zero or multiple matches.
-    """
-    from ..core.exceptions import {variables["AppName"]}Error
-
-    matches = [item for item in items if str(item.get(key, "")).startswith(partial)]
-    if len(matches) == 0:
-        raise {variables["AppName"]}Error(f"No item found matching '{{partial}}'")
-    if len(matches) > 1:
-        ids = [str(m.get(key, "")) for m in matches[:5]]
-        raise {variables["AppName"]}Error(f"Ambiguous ID '{{partial}}', matches: {{', '.join(ids)}}")
-    return matches[0]''')
-
-    if has_polling:
-        sections.append(f'''
-
-def poll_until_complete(
-    check_fn,
-    *,
-    timeout: float = 300.0,
-    initial_delay: float = 2.0,
-    max_delay: float = 10.0,
-    backoff_factor: float = 1.5,
-):
-    """Poll check_fn with exponential backoff until it returns a truthy value.
-
-    Args:
-        check_fn: Callable that returns a result (truthy = done) or None/falsy.
-        timeout: Maximum total wait time in seconds.
-        initial_delay: First sleep interval.
-        max_delay: Cap on sleep interval.
-        backoff_factor: Multiplier per iteration.
-
-    Returns:
-        The truthy result from check_fn.
-
-    Raises:
-        {variables["AppName"]}Error if timeout is exceeded.
-    """
-    import time
-
-    from ..core.exceptions import {variables["AppName"]}Error
-
-    elapsed = 0.0
-    delay = initial_delay
-    while elapsed < timeout:
-        result = check_fn()
-        if result:
-            return result
-        time.sleep(delay)
-        elapsed += delay
-        delay = min(delay * backoff_factor, max_delay)
-    raise {variables["AppName"]}Error(f"Operation timed out after {{timeout}}s")''')
-
-    if has_context:
-        sections.append('''
-
-def get_context_value(key: str) -> str | None:
-    """Read a value from the persistent context file."""
-    import json as _json
-
-    from ..core.config import CONFIG_DIR, CONTEXT_FILE
-
-    path = CONFIG_DIR / CONTEXT_FILE
-    if not path.exists():
-        return None
-    data = _json.loads(path.read_text())
-    return data.get(key)
-
-
-def set_context_value(key: str, value: str) -> None:
-    """Write a value to the persistent context file."""
-    import json as _json
-
-    from ..core.config import CONFIG_DIR, CONTEXT_FILE
-
-    path = CONFIG_DIR / CONTEXT_FILE
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    data = {}
-    if path.exists():
-        data = _json.loads(path.read_text())
-    data[key] = value
-    path.write_text(_json.dumps(data, indent=2))''')
-
-    if sections:
-        content += "\n" + "\n".join(sections) + "\n"
-
+    for flag_name, fragment_name in _HELPER_FRAGMENTS:
+        if flags[flag_name]:
+            content += render_template(TEMPLATES_DIR / fragment_name, variables)
     return content
 
 
@@ -351,14 +239,23 @@ def build_setup_py(variables: dict, http_client: str, auth_type: str, protocol: 
 
     install_requires = "\n        ".join(deps)
 
-    # Build extras_require
+    # Build extras_require as a complete block so we emit nothing when empty
+    # (setup.py treats an empty `extras_require={}` as clutter).
     extras = []
     if auth_type in ("cookie", "google-sso"):
         extras.append('"browser": ["playwright>=1.40.0"],')
 
-    extras_require = "\n        ".join(extras) if extras else ""
+    if extras:
+        extras_body = "\n        ".join(extras)
+        extras_require_block = f"extras_require={{\n        {extras_body}\n    }},"
+    else:
+        extras_require_block = ""
 
-    variables = {**variables, "install_requires": install_requires, "extras_require": extras_require}
+    variables = {
+        **variables,
+        "install_requires": install_requires,
+        "extras_require_block": extras_require_block,
+    }
     return render_template(TEMPLATES_DIR / "setup.py.tpl", variables)
 
 
@@ -425,23 +322,20 @@ def scaffold(
         render_template(TEMPLATES_DIR / "exceptions.py.tpl", variables),
     )
 
-    # config.py (conditional on auth_type + has_context)
-    write_file(
-        core_dir / "config.py",
-        build_config(variables, auth_type, has_context),
-    )
-
     # client.py (variant based on protocol + http_client)
     write_file(
         core_dir / "client.py",
         build_client(variables, protocol, http_client),
     )
 
-    # auth.py (conditional)
+    # auth.py (conditional + variant by auth_type)
+    # google-sso needs the regional-cookie-priority + login_browser scaffold;
+    # cookie and api-key use the generic thin template.
     if auth_type != "none":
+        auth_tpl_name = "auth_google_sso.py.tpl" if auth_type == "google-sso" else "auth.py.tpl"
         write_file(
             core_dir / "auth.py",
-            render_template(TEMPLATES_DIR / "auth.py.tpl", variables),
+            render_template(TEMPLATES_DIR / auth_tpl_name, variables),
         )
 
     # rpc/ subpackage (batchexecute only)
@@ -584,7 +478,24 @@ Examples:
 
     args = parser.parse_args()
 
+    # --app-name must convert to a valid Python identifier — generated code
+    # uses it for package names, module imports, and env var suffixes.
+    app_underscore = to_underscore(args.app_name)
+    if not app_underscore.isidentifier() or app_underscore.startswith("_"):
+        parser.error(
+            f"--app-name {args.app_name!r} converts to {app_underscore!r}, which "
+            f"is not a valid Python package name. Use only letters, digits, "
+            f"underscores, or hyphens; must start with a letter."
+        )
+    if not args.app_name[0].isalpha():
+        parser.error(
+            f"--app-name {args.app_name!r} must start with a letter "
+            f"(generated Python packages cannot start with a digit)."
+        )
+
     resources = [r.strip() for r in args.resources.split(",") if r.strip()]
+    if not resources:
+        parser.error("--resources must not be empty; pass at least one resource name.")
 
     scaffold(
         output_dir=args.output_dir.resolve(),

--- a/cli-anything-web-plugin/scripts/site-fingerprint.js
+++ b/cli-anything-web-plugin/scripts/site-fingerprint.js
@@ -4,7 +4,53 @@ async page => {
   const mainResult = await page.evaluate(() => {
     const body = document.body ? document.body.textContent.toLowerCase() : "";
     const html = document.documentElement.outerHTML;
+    const title = (document.title || "").toLowerCase();
     const scripts = Array.from(document.querySelectorAll("script[src]")).map(s => s.src);
+    const scriptsLower = scripts.map(s => s.toLowerCase());
+    const cookie = document.cookie || "";
+
+    // Cloudflare "managed challenge" (interstitial) — a site with cf_clearance
+    // is still protected but reachable; a site SHOWING the challenge now cannot
+    // be captured headless and requires camoufox.
+    const cloudflareManagedChallenge = (
+      title.includes("just a moment") ||
+      body.includes("checking if the site connection is secure") ||
+      body.includes("verifying you are human") ||
+      !!document.querySelector("#challenge-stage, #challenge-running, .cf-browser-verification")
+    );
+
+    // AWS WAF — sites like Booking.com return a 202 JS-challenge page to raw
+    // HTTP clients. Signals (when browser-rendered): aws-waf-token cookie,
+    // CAPTCHA script, or "automated access" body text.
+    const awsWafChallenge = (
+      cookie.includes("aws-waf-token") ||
+      scriptsLower.some(s => s.includes("captcha.prod.us-west-2.amazonaws.com") ||
+                             s.includes("tokenapi") ||
+                             s.includes("awswaf")) ||
+      html.includes("aws-waf-token") ||
+      body.includes("automated access")
+    );
+
+    // Akamai Bot Manager — multiple fingerprint signals beyond the script URL.
+    const akamaiBotManager = (
+      scriptsLower.some(s => s.includes("akamai") ||
+                             s.includes("akstat") ||
+                             s.endsWith("/_bm/sensor") ||
+                             s.includes("_bm.js") ||
+                             s.includes("/akam/")) ||
+      cookie.includes("_abck") ||
+      cookie.includes("bm_sz") ||
+      cookie.includes("bm_sv")
+    );
+
+    // DataDome — check for both scripts and its interstitial page.
+    const datadomeActive = (
+      scriptsLower.some(s => s.includes("datadome")) ||
+      cookie.includes("datadome") ||
+      body.includes("datadome") ||
+      !!document.querySelector("#dd-captcha-container, [data-cf-origin=datadome]")
+    );
+
     return {
       framework: {
         nextPages: !!document.getElementById("__NEXT_DATA__"),
@@ -20,13 +66,14 @@ async page => {
         preloadedState: typeof window.__INITIAL_STATE__ !== "undefined" || typeof window.__PRELOADED_STATE__ !== "undefined"
       },
       protection: {
-        cloudflare: html.includes("cf-ray") || html.includes("__cf_bm") || !!document.cookie.match(/__cf_bm/),
+        cloudflare: html.includes("cf-ray") || html.includes("__cf_bm") || !!cookie.match(/__cf_bm|cf_clearance/),
+        cloudflareManagedChallenge: cloudflareManagedChallenge,
         captcha: !!(document.querySelector(".g-recaptcha") || document.querySelector("#px-captcha") || document.querySelector(".h-captcha")),
-        akamai: scripts.some(function(s) { return s.includes("akamai"); }),
-        datadome: scripts.some(function(s) { return s.includes("datadome"); }),
-        perimeterx: scripts.some(function(s) { return s.includes("perimeterx") || s.includes("/px/"); }),
-        awsWaf: html.includes("aws-waf-token") || body.includes("automated access"),
-        rateLimit: document.title.includes("429") || document.title.toLowerCase().includes("too many requests"),
+        akamai: akamaiBotManager,
+        datadome: datadomeActive,
+        perimeterx: scriptsLower.some(s => s.includes("perimeterx") || s.includes("/px/")) || cookie.includes("_px"),
+        awsWaf: awsWafChallenge,
+        rateLimit: title.includes("429") || title.includes("too many requests"),
         serviceWorker: !!(navigator.serviceWorker && navigator.serviceWorker.controller)
       },
       auth: {

--- a/cli-anything-web-plugin/scripts/state_utils.py
+++ b/cli-anything-web-plugin/scripts/state_utils.py
@@ -1,0 +1,46 @@
+"""Shared JSON-state I/O helpers for phase-state.py and capture-checkpoint.py.
+
+Both scripts manage a JSON state file in an app directory and need the same
+primitives: load-or-default, save-with-timestamp, UTC now. Extracted here so
+there is one implementation — a bugfix (e.g., atomic write, file locking)
+lands in one place.
+
+Note: Deliberately does NOT unify the two scripts' schemas or CLIs. Skills
+invoke them by subcommand, and changing either public surface would break
+downstream callers.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def utc_now_iso() -> str:
+    """Return current UTC time as an ISO-8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json_state(path: Path, default: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    """Load a JSON state file. If missing, return `default` (None if not given).
+
+    Returns None-by-default lets callers distinguish 'no state yet' from an
+    empty dict.
+    """
+    if not path.exists():
+        return default
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json_state(path: Path, state: dict[str, Any]) -> None:
+    """Write state as JSON, stamping `updated_at` with current UTC time.
+
+    Creates parent directories as needed. Mutates `state` by setting
+    `updated_at`.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    state["updated_at"] = utc_now_iso()
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, ensure_ascii=False)

--- a/cli-anything-web-plugin/scripts/tests/conftest.py
+++ b/cli-anything-web-plugin/scripts/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Shared fixtures for plugin-script tests.
+
+The scripts aren't a proper package (they use hyphenated filenames and are
+invoked as CLI tools), so tests load them by absolute path via importlib.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+
+
+def load_script(filename: str, module_name: str | None = None) -> ModuleType:
+    """Load a hyphenated script file as an importable module.
+
+    Args:
+        filename: e.g. "scaffold-cli.py"
+        module_name: optional override for sys.modules key
+    """
+    path = SCRIPTS_DIR / filename
+    if not path.exists():
+        raise FileNotFoundError(f"Script not found: {path}")
+    name = module_name or filename.replace("-", "_").replace(".py", "")
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="session")
+def scaffold_cli() -> ModuleType:
+    return load_script("scaffold-cli.py", "scaffold_cli")
+
+
+@pytest.fixture(scope="session")
+def parse_trace() -> ModuleType:
+    return load_script("parse-trace.py", "parse_trace")
+
+
+@pytest.fixture(scope="session")
+def analyze_traffic() -> ModuleType:
+    return load_script("analyze-traffic.py", "analyze_traffic")

--- a/cli-anything-web-plugin/scripts/tests/test_analyze_traffic.py
+++ b/cli-anything-web-plugin/scripts/tests/test_analyze_traffic.py
@@ -1,0 +1,136 @@
+"""Tests for analyze-traffic.py: protocol detection, noise filtering, helpers."""
+from __future__ import annotations
+
+
+def _entry(url, method="GET", status=200, post_data=None, req_headers=None, resp_headers=None, mime="application/json"):
+    """Build a traffic entry in the shape produced by parse-trace.py."""
+    return {
+        "url": url,
+        "method": method,
+        "status": status,
+        "mime_type": mime,
+        "post_data": post_data,
+        "request_headers": req_headers or {},
+        "response_headers": resp_headers or {},
+        "response_body": None,
+    }
+
+
+# --- Header normalization ---
+
+def test_normalize_headers_accepts_dict(analyze_traffic):
+    assert analyze_traffic._normalize_headers({"A": "1"}) == {"A": "1"}
+
+
+def test_normalize_headers_accepts_list_format(analyze_traffic):
+    playwright_style = [{"name": "A", "value": "1"}, {"name": "B", "value": "2"}]
+    assert analyze_traffic._normalize_headers(playwright_style) == {"A": "1", "B": "2"}
+
+
+def test_normalize_headers_handles_none(analyze_traffic):
+    assert analyze_traffic._normalize_headers(None) == {}
+
+
+def test_normalize_headers_handles_malformed_list(analyze_traffic):
+    # Non-dict list items must not crash the normalizer
+    result = analyze_traffic._normalize_headers([{"name": "A", "value": "1"}, "not-a-dict"])
+    assert result == {"A": "1"}
+
+
+# --- Noise detection ---
+
+def test_noise_detects_google_analytics(analyze_traffic):
+    assert analyze_traffic._is_noise_url("https://google-analytics.com/collect") is True
+
+
+def test_noise_detects_facebook_tracking(analyze_traffic):
+    assert analyze_traffic._is_noise_url("https://facebook.com/tr?id=1") is True
+
+
+def test_noise_detects_datadog(analyze_traffic):
+    assert analyze_traffic._is_noise_url("https://browser-intake-datadoghq.com/v1/input") is True
+
+
+def test_noise_rejects_real_api(analyze_traffic):
+    assert analyze_traffic._is_noise_url("https://api.example.com/v1/users") is False
+
+
+def test_noise_rejects_graphql_endpoint(analyze_traffic):
+    assert analyze_traffic._is_noise_url("https://example.com/graphql") is False
+
+
+# --- Protocol detection ---
+
+def test_detect_protocol_graphql(analyze_traffic):
+    entries = [
+        _entry("https://api.example.com/graphql", method="POST",
+               post_data='{"operationName":"GetUser","query":"query GetUser {user{id}}"}'),
+        _entry("https://api.example.com/graphql", method="POST",
+               post_data='{"operationName":"UpdateUser","query":"mutation UpdateUser {updateUser(id:1){id}}"}'),
+    ]
+    result = analyze_traffic.detect_protocol(entries)
+    assert result["protocol"] == "graphql"
+    op_names = [op["name"] for op in result["graphql_operations"]]
+    assert "GetUser" in op_names
+    assert "UpdateUser" in op_names
+
+
+def test_detect_protocol_batchexecute(analyze_traffic):
+    entries = [
+        _entry(
+            "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=abc123&source=bl",
+            method="POST",
+            post_data='f.req=%5B%5B%5B%22abc123%22%2C%22%5B%5D%22%2Cnull%2C%22generic%22%5D%5D%5D',
+        )
+    ]
+    result = analyze_traffic.detect_protocol(entries)
+    assert result["protocol"] == "batchexecute"
+    assert "abc123" in result["batchexecute_rpc_ids"]
+
+
+def test_detect_protocol_rest(analyze_traffic):
+    entries = [
+        _entry("https://api.example.com/v1/users"),
+        _entry("https://api.example.com/v1/users/1"),
+        _entry("https://api.example.com/v1/posts"),
+    ]
+    result = analyze_traffic.detect_protocol(entries)
+    assert result["protocol"] == "rest"
+
+
+def test_detect_protocol_ignores_noise(analyze_traffic):
+    """Pure tracking traffic must not be classified as a real protocol."""
+    entries = [
+        _entry("https://google-analytics.com/collect", method="POST"),
+        _entry("https://facebook.com/tr?id=1", method="POST"),
+    ]
+    result = analyze_traffic.detect_protocol(entries)
+    # With only noise, confidence should be low or protocol "unknown"
+    assert result["confidence"] <= 50 or result["protocol"] in ("unknown", "rest")
+
+
+# --- End-to-end analyze() ---
+
+def test_analyze_empty_input(analyze_traffic):
+    report = analyze_traffic.analyze([])
+    assert "protocol" in report
+    assert "auth" in report
+    assert "stats" in report
+    assert report["stats"]["total_requests"] == 0
+
+
+def test_analyze_returns_all_sections(analyze_traffic):
+    entries = [_entry("https://api.example.com/v1/users")]
+    report = analyze_traffic.analyze(entries)
+    for key in (
+        "_meta", "protocol", "auth", "protections", "endpoints",
+        "rate_limits", "pagination", "stats", "suggested_commands",
+        "request_sequence", "session_lifecycle", "endpoint_sizes",
+    ):
+        assert key in report, f"missing section: {key}"
+
+
+def test_analyze_meta_reports_version(analyze_traffic):
+    report = analyze_traffic.analyze([])
+    assert report["_meta"]["tool"] == "analyze-traffic.py"
+    assert "version" in report["_meta"]

--- a/cli-anything-web-plugin/scripts/tests/test_analyze_traffic.py
+++ b/cli-anything-web-plugin/scripts/tests/test_analyze_traffic.py
@@ -16,47 +16,8 @@ def _entry(url, method="GET", status=200, post_data=None, req_headers=None, resp
     }
 
 
-# --- Header normalization ---
-
-def test_normalize_headers_accepts_dict(analyze_traffic):
-    assert analyze_traffic._normalize_headers({"A": "1"}) == {"A": "1"}
-
-
-def test_normalize_headers_accepts_list_format(analyze_traffic):
-    playwright_style = [{"name": "A", "value": "1"}, {"name": "B", "value": "2"}]
-    assert analyze_traffic._normalize_headers(playwright_style) == {"A": "1", "B": "2"}
-
-
-def test_normalize_headers_handles_none(analyze_traffic):
-    assert analyze_traffic._normalize_headers(None) == {}
-
-
-def test_normalize_headers_handles_malformed_list(analyze_traffic):
-    # Non-dict list items must not crash the normalizer
-    result = analyze_traffic._normalize_headers([{"name": "A", "value": "1"}, "not-a-dict"])
-    assert result == {"A": "1"}
-
-
-# --- Noise detection ---
-
-def test_noise_detects_google_analytics(analyze_traffic):
-    assert analyze_traffic._is_noise_url("https://google-analytics.com/collect") is True
-
-
-def test_noise_detects_facebook_tracking(analyze_traffic):
-    assert analyze_traffic._is_noise_url("https://facebook.com/tr?id=1") is True
-
-
-def test_noise_detects_datadog(analyze_traffic):
-    assert analyze_traffic._is_noise_url("https://browser-intake-datadoghq.com/v1/input") is True
-
-
-def test_noise_rejects_real_api(analyze_traffic):
-    assert analyze_traffic._is_noise_url("https://api.example.com/v1/users") is False
-
-
-def test_noise_rejects_graphql_endpoint(analyze_traffic):
-    assert analyze_traffic._is_noise_url("https://example.com/graphql") is False
+# Noise/header helpers live in traffic_utils and are tested directly in
+# test_traffic_utils.py. Tests here focus on detect_protocol / analyze pipelines.
 
 
 # --- Protocol detection ---
@@ -105,8 +66,29 @@ def test_detect_protocol_ignores_noise(analyze_traffic):
         _entry("https://facebook.com/tr?id=1", method="POST"),
     ]
     result = analyze_traffic.detect_protocol(entries)
-    # With only noise, confidence should be low or protocol "unknown"
-    assert result["confidence"] <= 50 or result["protocol"] in ("unknown", "rest")
+    # With only noise, confidence should be low.
+    assert result["confidence"] <= 50
+
+
+def test_detect_protocol_handles_null_url(analyze_traffic):
+    """Entry with explicit `url: None` must not crash (was a regression)."""
+    entries = [{"url": None, "method": "GET", "status": 200, "request_headers": {}}]
+    result = analyze_traffic.detect_protocol(entries)
+    assert "protocol" in result  # doesn't crash
+
+
+def test_detect_protocol_handles_missing_url_field(analyze_traffic):
+    """Entry without a `url` key at all must not crash."""
+    entries = [{"method": "GET", "status": 200, "request_headers": {}}]
+    result = analyze_traffic.detect_protocol(entries)
+    assert "protocol" in result
+
+
+def test_analyze_handles_null_url_entries(analyze_traffic):
+    """Full analyze() pipeline must survive entries with null URLs."""
+    entries = [{"url": None}, _entry("https://api.example.com/v1/users")]
+    report = analyze_traffic.analyze(entries)
+    assert report["stats"]["total_requests"] == 2
 
 
 # --- End-to-end analyze() ---

--- a/cli-anything-web-plugin/scripts/tests/test_capture_checkpoint.py
+++ b/cli-anything-web-plugin/scripts/tests/test_capture_checkpoint.py
@@ -1,0 +1,134 @@
+"""Tests for capture-checkpoint.py — Phase-1 sub-step state.
+
+Drives the script via subprocess. Verifies that save → restore → update
+→ clear round-trip through a sensible pipeline resume shape.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+CHECKPOINT = SCRIPTS_DIR / "capture-checkpoint.py"
+
+
+def _run(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        [sys.executable, str(CHECKPOINT), *args],
+        capture_output=True, text=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(f"capture-checkpoint.py failed: {result.stderr}")
+    return result
+
+
+def _restore(app_dir: Path) -> dict:
+    return json.loads(_run("restore", str(app_dir)).stdout)
+
+
+# --- Cold start ---
+
+def test_restore_on_empty_app_reports_no_checkpoint(tmp_path):
+    payload = _restore(tmp_path)
+    assert payload["exists"] is False
+
+
+# --- Save lifecycle ---
+
+def test_save_creates_checkpoint_with_step(tmp_path):
+    _run("save", str(tmp_path), "--step", "assessment",
+         "--session", "sess1", "--url", "https://x.test")
+    payload = _restore(tmp_path)
+    assert payload["exists"] is True
+    assert payload["step"] == "assessment"
+    assert payload["session_name"] == "sess1"
+    assert payload["url"] == "https://x.test"
+
+
+def test_save_adds_trace_entry(tmp_path):
+    _run("save", str(tmp_path), "--step", "tracing",
+         "--trace-id", "trace-42", "--trace-purpose", "probe")
+    payload = _restore(tmp_path)
+    traces = payload["active_traces"]
+    assert len(traces) == 1
+    assert traces[0]["id"] == "trace-42"
+    assert traces[0]["purpose"] == "probe"
+    assert traces[0]["status"] == "active"
+
+
+def test_save_preserves_prior_fields(tmp_path):
+    _run("save", str(tmp_path), "--step", "assessment", "--session", "sess1")
+    _run("save", str(tmp_path), "--step", "post-auth", "--auth-saved")
+    payload = _restore(tmp_path)
+    # session carries over even though the second save didn't pass --session
+    assert payload["session_name"] == "sess1"
+    assert payload["step"] == "post-auth"
+    assert payload["auth_saved"] is True
+
+
+# --- Update ---
+
+def test_update_changes_specific_fields(tmp_path):
+    _run("save", str(tmp_path), "--step", "tracing", "--trace-id", "t1")
+    _run("update", str(tmp_path), "--step", "full-capture", "--auth-saved")
+    payload = _restore(tmp_path)
+    assert payload["step"] == "full-capture"
+    assert payload["auth_saved"] is True
+
+
+def test_update_errors_on_missing_checkpoint(tmp_path):
+    result = _run("update", str(tmp_path), "--step", "assessment", check=False)
+    assert result.returncode != 0
+    assert "No checkpoint" in result.stderr
+
+
+# --- Step sequencing / guidance ---
+
+def test_restore_computes_step_index_and_next(tmp_path):
+    _run("save", str(tmp_path), "--step", "assessment")
+    payload = _restore(tmp_path)
+    assert payload["step_index"] == 1  # 0=setup, 1=assessment
+    assert payload["next_step"] == "post-auth"
+    assert "completed_steps" in payload
+    assert "assessment" in payload["completed_steps"]
+
+
+def test_restore_complete_step_gives_ready_guidance(tmp_path):
+    _run("save", str(tmp_path), "--step", "complete")
+    payload = _restore(tmp_path)
+    assert payload["next_step"] == "done"
+    assert "Phase 2" in payload["guidance"]
+
+
+# --- Clear ---
+
+def test_clear_removes_checkpoint(tmp_path):
+    _run("save", str(tmp_path), "--step", "assessment")
+    _run("clear", str(tmp_path))
+    payload = _restore(tmp_path)
+    assert payload["exists"] is False
+
+
+def test_clear_when_no_checkpoint_is_a_no_op(tmp_path):
+    # Must not error when there's nothing to clear
+    _run("clear", str(tmp_path))
+
+
+# --- Assessment JSON ---
+
+def test_save_accepts_assessment_json(tmp_path):
+    _run("save", str(tmp_path), "--step", "assessment",
+         "--assessment", '{"framework":"next","protection":"cloudflare"}')
+    payload = _restore(tmp_path)
+    assert payload["assessment"]["framework"] == "next"
+    assert payload["assessment"]["protection"] == "cloudflare"
+
+
+def test_save_ignores_malformed_assessment_json(tmp_path):
+    # Should not crash; just warn and continue
+    result = _run("save", str(tmp_path), "--step", "assessment",
+                  "--assessment", "not json at all")
+    payload = _restore(tmp_path)
+    assert payload["exists"] is True

--- a/cli-anything-web-plugin/scripts/tests/test_generate_test_docs.py
+++ b/cli-anything-web-plugin/scripts/tests/test_generate_test_docs.py
@@ -1,0 +1,169 @@
+"""Tests for generate-test-docs.py — AST-based test plan extraction.
+
+Exercises parse_test_file() against synthetic test files and drives the
+full `plan` subcommand via subprocess to verify end-to-end output.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+GEN_DOCS = SCRIPTS_DIR / "generate-test-docs.py"
+
+
+@pytest.fixture(scope="module")
+def gen_docs_mod() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("generate_test_docs", GEN_DOCS)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["generate_test_docs"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- parse_test_file ---
+
+def test_parse_extracts_top_level_test_functions(gen_docs_mod, tmp_path):
+    src = tmp_path / "test_core.py"
+    src.write_text(
+        "def test_one():\n    pass\n\n"
+        "def test_two():\n    pass\n\n"
+        "def not_a_test():\n    pass\n"
+    )
+    result = gen_docs_mod.parse_test_file(src)
+    # Module-level funcs become the first entry
+    assert result, "expected at least one result"
+    module_entry = result[0]
+    assert "test_one" in module_entry["methods"]
+    assert "test_two" in module_entry["methods"]
+    assert "not_a_test" not in module_entry["methods"]
+
+
+def test_parse_extracts_test_classes_with_methods(gen_docs_mod, tmp_path):
+    src = tmp_path / "test_core.py"
+    src.write_text(
+        "class TestFoo:\n"
+        "    def test_a(self): pass\n"
+        "    def test_b(self): pass\n"
+        "    def helper(self): pass\n"
+        "\n"
+        "class NotATest:\n"
+        "    def test_ignored(self): pass\n"
+    )
+    result = gen_docs_mod.parse_test_file(src)
+    classes = [r["class"] for r in result]
+    assert "TestFoo" in classes
+    assert "NotATest" not in classes
+
+    foo = next(r for r in result if r["class"] == "TestFoo")
+    assert foo["methods"] == ["test_a", "test_b"]
+
+
+def test_parse_classifies_e2e_layer_by_filename(gen_docs_mod, tmp_path):
+    src = tmp_path / "test_e2e.py"
+    src.write_text("def test_live(): pass\n")
+    result = gen_docs_mod.parse_test_file(src)
+    assert result[0]["layer"] == "E2E (live)"
+
+
+def test_parse_classifies_unit_layer_by_filename(gen_docs_mod, tmp_path):
+    src = tmp_path / "test_core.py"
+    src.write_text("def test_mocked(): pass\n")
+    result = gen_docs_mod.parse_test_file(src)
+    assert "Unit" in result[0]["layer"]
+
+
+def test_parse_class_name_overrides_default_layer(gen_docs_mod, tmp_path):
+    """TestSubprocessFoo in test_e2e.py should be classified as Subprocess,
+    not E2E, because the class name takes priority."""
+    src = tmp_path / "test_e2e.py"
+    src.write_text(
+        "class TestSubprocessFoo:\n"
+        "    def test_spawn(self): pass\n"
+    )
+    result = gen_docs_mod.parse_test_file(src)
+    classes = {r["class"]: r["layer"] for r in result}
+    assert classes["TestSubprocessFoo"] == "Subprocess"
+
+
+def test_parse_ignores_syntax_errors(gen_docs_mod, tmp_path):
+    """Malformed .py file should return [] rather than crash."""
+    src = tmp_path / "broken.py"
+    src.write_text("def test_broken(\n")
+    assert gen_docs_mod.parse_test_file(src) == []
+
+
+def test_parse_skips_classes_with_no_test_methods(gen_docs_mod, tmp_path):
+    src = tmp_path / "test_core.py"
+    src.write_text(
+        "class TestEmpty:\n    pass\n\n"
+        "class TestReal:\n    def test_x(self): pass\n"
+    )
+    result = gen_docs_mod.parse_test_file(src)
+    class_names = [r["class"] for r in result]
+    assert "TestEmpty" not in class_names
+    assert "TestReal" in class_names
+
+
+def test_parse_handles_empty_file(gen_docs_mod, tmp_path):
+    src = tmp_path / "empty.py"
+    src.write_text("")
+    assert gen_docs_mod.parse_test_file(src) == []
+
+
+# --- generate_plan via subprocess ---
+
+def test_plan_subcommand_generates_markdown(tmp_path):
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_core.py").write_text(
+        "class TestClient:\n    def test_fetch(self): pass\n"
+    )
+    result = subprocess.run(
+        [
+            sys.executable, str(GEN_DOCS), "plan",
+            str(tests_dir), "--app-name", "myapp",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    # Plan subcommand writes TEST.md next to tests/ (under the harness root).
+    # Locate it: either in tests_dir, its parent, or stdout.
+    for candidate in (tests_dir / "TEST.md", tests_dir.parent / "TEST.md"):
+        if candidate.exists():
+            markdown = candidate.read_text()
+            break
+    else:
+        markdown = result.stdout
+    assert "myapp" in markdown
+    assert "TestClient" in markdown or "test_fetch" in markdown
+
+
+def test_plan_handles_empty_tests_dir(tmp_path):
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    result = subprocess.run(
+        [
+            sys.executable, str(GEN_DOCS), "plan",
+            str(tests_dir), "--app-name", "empty",
+        ],
+        capture_output=True, text=True,
+    )
+    # Should not crash; output may be empty / minimal
+    assert result.returncode == 0, result.stderr
+
+
+def test_rejects_nonexistent_tests_dir():
+    result = subprocess.run(
+        [
+            sys.executable, str(GEN_DOCS), "plan",
+            "/nonexistent/path/xyz", "--app-name", "x",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0

--- a/cli-anything-web-plugin/scripts/tests/test_mitmproxy_capture.py
+++ b/cli-anything-web-plugin/scripts/tests/test_mitmproxy_capture.py
@@ -1,0 +1,176 @@
+"""Tests for mitmproxy-capture.py.
+
+mitmproxy is an optional dependency of the plugin; these tests are skipped
+when it's not installed. When installed, they cover the pure helpers that
+don't require a live proxy or browser:
+
+- `write_output()` JSON schema
+- state/signal file path helpers
+- `_is_pid_alive()` process-liveness check
+- `_cleanup_state_files()` idempotency
+- `_flush_traffic()` incremental writer
+
+The noise/static filtering helpers (`_is_noise` / `_is_static`) are aliased
+from `traffic_utils` and already have dedicated coverage there.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+MITMPROXY_CAPTURE = SCRIPTS_DIR / "mitmproxy-capture.py"
+
+
+def _has_mitmproxy() -> bool:
+    return importlib.util.find_spec("mitmproxy") is not None
+
+
+# --- Environment-agnostic CLI contract checks ---
+
+def test_script_exists_with_python_shebang():
+    assert MITMPROXY_CAPTURE.exists()
+    first_line = MITMPROXY_CAPTURE.read_text(encoding="utf-8").splitlines()[0]
+    assert first_line.startswith("#!") and "python" in first_line
+
+
+@pytest.mark.skipif(not _has_mitmproxy(), reason="mitmproxy not installed")
+def test_help_output_lists_subcommands():
+    """When mitmproxy is installed, --help must list start-proxy / stop-proxy / capture."""
+    result = subprocess.run(
+        [sys.executable, str(MITMPROXY_CAPTURE), "--help"],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert result.returncode == 0
+    for cmd in ("start-proxy", "stop-proxy", "capture"):
+        assert cmd in result.stdout
+
+
+# --- In-process helper tests (only runnable with mitmproxy) ---
+
+# The capture script imports mitmproxy at module-top, so we can't load
+# it in-process without the dep. Helper tests below are guarded.
+
+pytestmark_needs_mitmproxy = pytest.mark.skipif(
+    not _has_mitmproxy(), reason="mitmproxy not installed"
+)
+
+
+@pytest.fixture(scope="module")
+def mod() -> ModuleType:
+    if not _has_mitmproxy():
+        pytest.skip("mitmproxy not installed")
+    spec = importlib.util.spec_from_file_location("mitmproxy_capture", MITMPROXY_CAPTURE)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["mitmproxy_capture"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+# --- Static + noise filters (smoke-level; full coverage in traffic_utils) ---
+
+def test_is_static_filter_catches_js(mod):
+    assert mod._is_static("https://cdn.example.com/app.js") is True
+
+
+def test_is_static_filter_catches_media_extensions(mod):
+    assert mod._is_static("https://cdn.example.com/clip.mp4") is True
+
+
+def test_is_static_filter_rejects_api_url(mod):
+    assert mod._is_static("https://api.example.com/v1/users") is False
+
+
+# --- State file paths ---
+
+def test_state_file_paths_are_distinct_per_port(mod):
+    p0 = mod._state_file_path(0)
+    p1 = mod._state_file_path(8080)
+    p2 = mod._state_file_path(9090)
+    assert p0 != p1 != p2
+
+
+def test_stop_signal_path_distinct_from_state(mod):
+    state = mod._state_file_path(8080)
+    stop = mod._stop_signal_path(8080)
+    assert state != stop
+
+
+# --- PID liveness check ---
+
+def test_is_pid_alive_true_for_self(mod):
+    assert mod._is_pid_alive(os.getpid()) is True
+
+
+def test_is_pid_alive_false_for_unlikely_pid(mod):
+    # 2**31 - 1 is valid on Linux but virtually never assigned.
+    assert mod._is_pid_alive(2147483647) is False
+
+
+# --- write_output JSON schema ---
+
+def test_write_output_produces_valid_json(mod, tmp_path):
+    entries = [
+        {"url": "https://api.example.com/v1/items", "method": "GET", "status": 200},
+        {"url": "https://api.example.com/v1/items", "method": "POST", "status": 201},
+    ]
+    stats = {"captured": 2, "filtered": 0}
+    out = tmp_path / "raw.json"
+    mod.write_output(entries, out, stats)
+    assert out.exists()
+    data = json.loads(out.read_text())
+    # Shape: either list of entries (legacy) or dict with entries + stats
+    if isinstance(data, dict):
+        assert "entries" in data or "captured" in data or len(data) > 0
+    else:
+        assert isinstance(data, list)
+        assert len(data) == 2
+
+
+def test_write_output_creates_parent_directories(mod, tmp_path):
+    out = tmp_path / "deep" / "nested" / "raw.json"
+    mod.write_output([], out, {"captured": 0})
+    assert out.exists()
+
+
+# --- Read-state returns None when file absent ---
+
+def test_read_state_returns_none_when_missing(mod):
+    # Use a very unlikely port to guarantee no state file
+    assert mod._read_state(port=9999) is None
+
+
+# --- cleanup is idempotent ---
+
+def test_cleanup_state_files_is_no_op_when_absent(mod):
+    # Must not raise when there's nothing to clean
+    mod._cleanup_state_files(port=9999)
+
+
+# --- _flush_traffic writes JSON-serializable entries ---
+
+def test_flush_traffic_writes_entries_to_disk(mod, tmp_path):
+    out = tmp_path / "flush.json"
+    entries = [{"url": "https://x.test", "method": "GET", "status": 200}]
+    mod._flush_traffic(entries, out)
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert isinstance(data, list)
+    assert data[0]["url"] == "https://x.test"
+
+
+def test_flush_traffic_overwrites_existing_file(mod, tmp_path):
+    out = tmp_path / "flush.json"
+    mod._flush_traffic([{"url": "old", "method": "GET", "status": 200}], out)
+    mod._flush_traffic([{"url": "new", "method": "GET", "status": 200}], out)
+    data = json.loads(out.read_text())
+    assert len(data) == 1
+    assert data[0]["url"] == "new"

--- a/cli-anything-web-plugin/scripts/tests/test_parse_trace.py
+++ b/cli-anything-web-plugin/scripts/tests/test_parse_trace.py
@@ -1,0 +1,144 @@
+"""Tests for parse-trace.py: .network file parsing, static-asset filtering."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _write_trace(traces_dir: Path, entries: list[dict]) -> Path:
+    """Write a minimal .network file + resources/ structure."""
+    traces_dir.mkdir(parents=True, exist_ok=True)
+    resources_dir = traces_dir / "resources"
+    resources_dir.mkdir(exist_ok=True)
+
+    lines = []
+    for entry in entries:
+        body = entry.pop("_body", None)
+        sha1 = None
+        if body is not None:
+            sha1 = f"sha_{len(lines)}"
+            (resources_dir / sha1).write_text(
+                body if isinstance(body, str) else json.dumps(body)
+            )
+        resp = entry.get("snapshot", {}).get("response", {})
+        if sha1:
+            resp.setdefault("content", {})["_sha1"] = sha1
+        lines.append(json.dumps(entry))
+
+    network_file = traces_dir / "test.network"
+    network_file.write_text("\n".join(lines) + "\n")
+    return network_file
+
+
+def _make_entry(url: str, method: str = "GET", status: int = 200, body=None) -> dict:
+    entry = {
+        "type": "resource-snapshot",
+        "snapshot": {
+            "request": {
+                "url": url,
+                "method": method,
+                "headers": [{"name": "User-Agent", "value": "test"}],
+            },
+            "response": {
+                "status": status,
+                "headers": [{"name": "Content-Type", "value": "application/json"}],
+                "content": {"mimeType": "application/json"},
+            },
+            "time": 12.3,
+        },
+    }
+    if body is not None:
+        entry["_body"] = body
+    return entry
+
+
+def test_parse_single_json_entry(parse_trace, tmp_path):
+    _write_trace(tmp_path, [_make_entry("https://api.example.com/items", body={"ok": True})])
+
+    entries = parse_trace.parse_traces(tmp_path)
+    assert len(entries) == 1
+    assert entries[0]["url"] == "https://api.example.com/items"
+    assert entries[0]["method"] == "GET"
+    assert entries[0]["status"] == 200
+    assert entries[0]["response_body"] == {"ok": True}
+
+
+def test_parse_filters_static_assets_by_default(parse_trace, tmp_path):
+    _write_trace(tmp_path, [
+        _make_entry("https://cdn.example.com/style.css"),
+        _make_entry("https://cdn.example.com/script.js"),
+        _make_entry("https://cdn.example.com/logo.png"),
+        _make_entry("https://api.example.com/data", body={"ok": True}),
+    ])
+
+    entries = parse_trace.parse_traces(tmp_path, filter_static=True)
+    assert len(entries) == 1
+    assert entries[0]["url"].endswith("/data")
+
+
+def test_parse_includes_static_when_requested(parse_trace, tmp_path):
+    _write_trace(tmp_path, [
+        _make_entry("https://cdn.example.com/style.css"),
+        _make_entry("https://api.example.com/data"),
+    ])
+
+    entries = parse_trace.parse_traces(tmp_path, filter_static=False)
+    assert len(entries) == 2
+
+
+def test_parse_ignores_non_snapshot_events(parse_trace, tmp_path):
+    tmp_path.mkdir(exist_ok=True)
+    net = tmp_path / "x.network"
+    net.write_text(json.dumps({"type": "other-event"}) + "\n")
+
+    entries = parse_trace.parse_traces(tmp_path)
+    assert entries == []
+
+
+def test_parse_handles_empty_network_file(parse_trace, tmp_path):
+    tmp_path.mkdir(exist_ok=True)
+    (tmp_path / "empty.network").write_text("")
+
+    entries = parse_trace.parse_traces(tmp_path)
+    assert entries == []
+
+
+def test_parse_skips_malformed_json_lines(parse_trace, tmp_path):
+    tmp_path.mkdir(exist_ok=True)
+    good = _make_entry("https://api.example.com/items", body={"ok": True})
+    net = tmp_path / "x.network"
+    net.write_text("not-json-at-all\n" + json.dumps(good) + "\n")
+
+    # Need to put the body file in resources/
+    (tmp_path / "resources").mkdir(exist_ok=True)
+
+    entries = parse_trace.parse_traces(tmp_path)
+    assert len(entries) == 1
+
+
+def test_parse_falls_back_to_text_body_when_not_json(parse_trace, tmp_path):
+    _write_trace(tmp_path, [_make_entry("https://api.example.com/p", body="<html>plain</html>")])
+    entries = parse_trace.parse_traces(tmp_path)
+    assert entries[0]["response_body"] == "<html>plain</html>"
+
+
+def test_parse_latest_only_picks_newest(parse_trace, tmp_path):
+    import os, time
+    tmp_path.mkdir(exist_ok=True)
+    (tmp_path / "resources").mkdir(exist_ok=True)
+
+    old = _make_entry("https://api.example.com/old")
+    (tmp_path / "1.network").write_text(json.dumps(old) + "\n")
+    time.sleep(0.05)
+    new = _make_entry("https://api.example.com/new")
+    (tmp_path / "2.network").write_text(json.dumps(new) + "\n")
+    # Force 2.network to be newer
+    os.utime(tmp_path / "1.network", (1, 1))
+
+    entries = parse_trace.parse_traces(tmp_path, latest_only=True)
+    assert len(entries) == 1
+    assert "/new" in entries[0]["url"]
+
+
+def test_parse_empty_dir_returns_empty(parse_trace, tmp_path):
+    assert parse_trace.parse_traces(tmp_path) == []

--- a/cli-anything-web-plugin/scripts/tests/test_phase_state.py
+++ b/cli-anything-web-plugin/scripts/tests/test_phase_state.py
@@ -1,0 +1,140 @@
+"""Tests for phase-state.py — pipeline phase tracking (4-phase CLI lifecycle).
+
+phase-state.py is a CLI tool used by every Phase 2/3/4 skill to check whether
+the previous phase is done and to mark the current one complete/failed. These
+tests drive it via subprocess to mirror real usage.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+PHASE_STATE = SCRIPTS_DIR / "phase-state.py"
+
+
+def _run(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        [sys.executable, str(PHASE_STATE), *args],
+        capture_output=True, text=True,
+    )
+    if check and result.returncode not in (0, 1):
+        raise AssertionError(f"phase-state.py failed: {result.stderr}")
+    return result
+
+
+def _status(app_dir: Path) -> dict:
+    return json.loads(_run("status", str(app_dir)).stdout)
+
+
+# --- Fresh state ---
+
+def test_status_on_fresh_app_reports_all_phases_pending(tmp_path):
+    report = _status(tmp_path)
+    for phase in ("capture", "methodology", "testing", "standards"):
+        assert report["phases"][phase]["status"] == "pending"
+    assert report["current_phase"] == "capture"
+    assert "Run capture phase" in report["next_action"]
+
+
+# --- complete ---
+
+def test_complete_marks_phase_done_and_persists_output(tmp_path):
+    _run("complete", str(tmp_path), "--phase", "capture", "--output", "/tmp/raw.json", "--notes", "went fine")
+    report = _status(tmp_path)
+    assert report["phases"]["capture"]["status"] == "done"
+    assert report["phases"]["capture"]["output"] == "/tmp/raw.json"
+    assert report["phases"]["capture"]["notes"] == "went fine"
+    assert "completed_at" in report["phases"]["capture"]
+    assert report["current_phase"] == "methodology"
+
+
+def test_completing_phase_writes_state_file(tmp_path):
+    _run("complete", str(tmp_path), "--phase", "capture")
+    state_file = tmp_path / "phase-state.json"
+    assert state_file.exists()
+    state = json.loads(state_file.read_text())
+    assert state["phases"]["capture"]["status"] == "done"
+    assert "updated_at" in state
+
+
+# --- fail ---
+
+def test_fail_marks_phase_with_error_and_type(tmp_path):
+    _run("fail", str(tmp_path), "--phase", "testing",
+         "--error", "3 tests failed", "--error-type", "retryable")
+    report = _status(tmp_path)
+    assert report["phases"]["testing"]["status"] == "failed"
+    assert report["phases"]["testing"]["error"] == "3 tests failed"
+    assert report["phases"]["testing"]["error_type"] == "retryable"
+
+
+def test_failed_phase_shows_in_next_action(tmp_path):
+    # Mark capture done so the next-action logic picks up on a real failure
+    _run("complete", str(tmp_path), "--phase", "capture")
+    _run("fail", str(tmp_path), "--phase", "methodology",
+         "--error", "boom", "--error-type", "retryable")
+    report = _status(tmp_path)
+    # current_phase should point at the failed phase
+    assert report["current_phase"] == "methodology"
+    assert "Retry" in report["next_action"] or "fix" in report["next_action"].lower()
+
+
+def test_fail_with_fatal_error_type_suggests_force(tmp_path):
+    _run("fail", str(tmp_path), "--phase", "capture", "--error", "boom", "--error-type", "fatal")
+    report = _status(tmp_path)
+    assert "--force" in report["next_action"] or "Fix" in report["next_action"]
+
+
+# --- reset ---
+
+def test_reset_returns_phase_to_pending(tmp_path):
+    _run("complete", str(tmp_path), "--phase", "capture")
+    _run("reset", str(tmp_path), "--phase", "capture")
+    report = _status(tmp_path)
+    assert report["phases"]["capture"]["status"] == "pending"
+
+
+# --- check (exit code contract) ---
+
+def test_check_exit_0_when_phase_done(tmp_path):
+    _run("complete", str(tmp_path), "--phase", "capture")
+    result = _run("check", str(tmp_path), "--phase", "capture", check=False)
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["skip"] is True
+
+
+def test_check_exit_1_when_phase_pending(tmp_path):
+    result = _run("check", str(tmp_path), "--phase", "capture", check=False)
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["skip"] is False
+
+
+def test_check_with_force_always_exits_1(tmp_path):
+    _run("complete", str(tmp_path), "--phase", "capture")
+    result = _run("check", str(tmp_path), "--phase", "capture", "--force", check=False)
+    assert result.returncode == 1
+
+
+# --- Pipeline-complete terminal state ---
+
+def test_all_phases_complete_shows_ready_message(tmp_path):
+    for phase in ("capture", "methodology", "testing", "standards"):
+        _run("complete", str(tmp_path), "--phase", phase)
+    report = _status(tmp_path)
+    assert report["current_phase"] is None
+    assert "complete" in report["next_action"].lower()
+
+
+# --- Argparse contract ---
+
+@pytest.mark.parametrize("bad_phase", ["setup", "build", "deploy", "CAPTURE"])
+def test_rejects_unknown_phase_name(tmp_path, bad_phase):
+    result = _run("complete", str(tmp_path), "--phase", bad_phase, check=False)
+    assert result.returncode != 0

--- a/cli-anything-web-plugin/scripts/tests/test_plugin_paths.py
+++ b/cli-anything-web-plugin/scripts/tests/test_plugin_paths.py
@@ -1,0 +1,35 @@
+"""Tests for plugin_paths.py — canonical path discovery."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import plugin_paths  # noqa: E402
+
+
+def test_plugin_root_is_parent_of_scripts():
+    assert plugin_paths.get_plugin_root() == SCRIPTS_DIR.parent
+
+
+def test_scripts_dir_matches_scripts_location():
+    assert plugin_paths.get_scripts_dir() == SCRIPTS_DIR
+
+
+def test_templates_dir_exists():
+    assert plugin_paths.get_templates_dir().is_dir()
+
+
+def test_skills_dir_exists():
+    assert plugin_paths.get_skills_dir().is_dir()
+
+
+def test_commands_dir_exists():
+    assert plugin_paths.get_commands_dir().is_dir()
+
+
+def test_agents_dir_exists():
+    assert plugin_paths.get_agents_dir().is_dir()

--- a/cli-anything-web-plugin/scripts/tests/test_plugin_paths.py
+++ b/cli-anything-web-plugin/scripts/tests/test_plugin_paths.py
@@ -21,15 +21,3 @@ def test_scripts_dir_matches_scripts_location():
 
 def test_templates_dir_exists():
     assert plugin_paths.get_templates_dir().is_dir()
-
-
-def test_skills_dir_exists():
-    assert plugin_paths.get_skills_dir().is_dir()
-
-
-def test_commands_dir_exists():
-    assert plugin_paths.get_commands_dir().is_dir()
-
-
-def test_agents_dir_exists():
-    assert plugin_paths.get_agents_dir().is_dir()

--- a/cli-anything-web-plugin/scripts/tests/test_rpc_templates.py
+++ b/cli-anything-web-plugin/scripts/tests/test_rpc_templates.py
@@ -1,0 +1,156 @@
+"""Tests for the batchexecute RPC templates.
+
+Renders a scaffolded CLI, imports the generated rpc/ modules, and verifies
+their behavior against realistic batchexecute inputs. This catches drift
+between the templates and production notebooklm/stitch implementations.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+SCAFFOLD = SCRIPTS_DIR / "scaffold-cli.py"
+
+
+@pytest.fixture(scope="module")
+def rpc_modules(tmp_path_factory):
+    """Scaffold a batchexecute CLI once and load its rpc/ modules."""
+    out_dir = tmp_path_factory.mktemp("rpc_scaffold") / "gen"
+    result = subprocess.run(
+        [
+            sys.executable, str(SCAFFOLD), str(out_dir),
+            "--app-name", "rpctest",
+            "--protocol", "batchexecute",
+            "--http-client", "httpx",
+            "--auth-type", "google-sso",
+            "--resources", "items",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    pkg_root = out_dir / "cli_web" / "rpctest"
+
+    # Make the generated package importable from this test process.
+    sys.path.insert(0, str(out_dir))
+
+    # Load the rpc submodules (skipping auth.py which requires playwright/httpx
+    # at import-time via fetch_tokens).
+    def _load(modname: str, path: Path):
+        spec = importlib.util.spec_from_file_location(modname, path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[modname] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    # Load exceptions first — decoder imports it.
+    _load("cli_web.rpctest", pkg_root / "__init__.py")
+    _load("cli_web.rpctest.core", pkg_root / "core" / "__init__.py")
+    _load("cli_web.rpctest.core.exceptions", pkg_root / "core" / "exceptions.py")
+    _load("cli_web.rpctest.core.rpc", pkg_root / "core" / "rpc" / "__init__.py")
+    types_mod = _load("cli_web.rpctest.core.rpc.types", pkg_root / "core" / "rpc" / "types.py")
+    encoder = _load("cli_web.rpctest.core.rpc.encoder", pkg_root / "core" / "rpc" / "encoder.py")
+    decoder = _load("cli_web.rpctest.core.rpc.decoder", pkg_root / "core" / "rpc" / "decoder.py")
+    return types_mod, encoder, decoder
+
+
+# --- Encoder ---
+
+def test_encode_request_returns_url_encoded_string(rpc_modules):
+    _, encoder, _ = rpc_modules
+    out = encoder.encode_request("wXbhsf", [None, 10], csrf_token="tok123")
+    # Must be URL-encoded form body (not a dict)
+    assert isinstance(out, str)
+    assert "f.req=" in out
+    assert "at=tok123" in out
+
+
+def test_build_url_includes_required_params(rpc_modules):
+    _, encoder, _ = rpc_modules
+    url = encoder.build_url(
+        "wXbhsf",
+        session_id="-123456",
+        build_label="boq_labstailwinduiserver_20250101.00_p0",
+        source_path="/notebook/abc",
+        req_id=200000,
+    )
+    assert "rpcids=wXbhsf" in url
+    assert "f.sid=-123456" in url
+    assert "bl=boq_labstailwinduiserver" in url
+    assert "_reqid=200000" in url
+
+
+def test_build_url_omits_build_label_when_empty(rpc_modules):
+    _, encoder, _ = rpc_modules
+    url = encoder.build_url("wXbhsf", session_id="1", build_label="", source_path="/")
+    assert "bl=" not in url
+
+
+# --- Decoder ---
+
+def test_strip_prefix_removes_anti_xssi(rpc_modules):
+    _, _, decoder = rpc_modules
+    assert decoder.strip_prefix(")]}'\n[[1,2]]") == "[[1,2]]"
+    assert decoder.strip_prefix("[[1,2]]") == "[[1,2]]"
+
+
+def test_strip_prefix_handles_bytes(rpc_modules):
+    _, _, decoder = rpc_modules
+    assert decoder.strip_prefix(b")]}'\n[1]") == "[1]"
+
+
+def test_parse_chunks_multi_chunk_response(rpc_modules):
+    """Real batchexecute responses contain multiple JSON chunks with length hints."""
+    _, _, decoder = rpc_modules
+    body = '11927\n[["wrb.fr","wXbhsf","\\"hello\\""]]\n27\n[["e",4,null,null,12542]]'
+    chunks = decoder.parse_chunks(body)
+    assert len(chunks) == 2
+    assert '"wrb.fr"' in chunks[0]
+    assert '"e"' in chunks[1]
+
+
+def test_parse_chunks_ignores_length_hint_lines(rpc_modules):
+    _, _, decoder = rpc_modules
+    body = '5\n[]\n10\n[[1]]'
+    assert len(decoder.parse_chunks(body)) == 2
+
+
+def test_extract_result_finds_rpc_payload(rpc_modules):
+    _, _, decoder = rpc_modules
+    chunks = ['[["wrb.fr","xyz","[1,2,3]"]]']
+    assert decoder.extract_result(chunks, "xyz") == [1, 2, 3]
+
+
+def test_extract_result_raises_auth_error_on_code_7(rpc_modules):
+    types, _, decoder = rpc_modules
+    from cli_web.rpctest.core.exceptions import AuthError
+    chunks = ['[["er",7,null,null,null]]']
+    with pytest.raises(AuthError):
+        decoder.extract_result(chunks, "xyz")
+
+
+def test_extract_result_raises_rpc_error_on_unknown_code(rpc_modules):
+    types, _, decoder = rpc_modules
+    from cli_web.rpctest.core.exceptions import RPCError
+    chunks = ['[["er",99,null]]']
+    with pytest.raises(RPCError):
+        decoder.extract_result(chunks, "xyz")
+
+
+def test_extract_result_raises_rpc_error_when_missing(rpc_modules):
+    _, _, decoder = rpc_modules
+    from cli_web.rpctest.core.exceptions import RPCError
+    chunks = ['[["wrb.fr","other","[]"]]']
+    with pytest.raises(RPCError):
+        decoder.extract_result(chunks, "wanted")
+
+
+def test_decode_response_full_pipeline(rpc_modules):
+    _, _, decoder = rpc_modules
+    body = ')]}\'\n35\n[["wrb.fr","xyz","[\\"ok\\"]"]]'
+    assert decoder.decode_response(body, "xyz") == ["ok"]

--- a/cli-anything-web-plugin/scripts/tests/test_run_pipeline.py
+++ b/cli-anything-web-plugin/scripts/tests/test_run_pipeline.py
@@ -1,0 +1,64 @@
+"""Tests for run-pipeline.py orchestrator."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+ORCH = SCRIPTS_DIR / "run-pipeline.py"
+PHASE_STATE = SCRIPTS_DIR / "phase-state.py"
+
+
+def test_status_reports_all_phases_pending_for_new_app(tmp_path):
+    result = subprocess.run(
+        [sys.executable, str(ORCH), "status", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    report = json.loads(result.stdout)
+    assert report["current_phase"] == "capture"
+    assert report["phases"]["capture"]["status"] == "pending"
+    assert report["next_action"]["skill"] == "capture"
+
+
+def test_status_advances_after_capture_done(tmp_path):
+    subprocess.check_call([
+        sys.executable, str(PHASE_STATE), "complete", str(tmp_path),
+        "--phase", "capture", "--output", "/tmp/foo.json",
+    ])
+    result = subprocess.run(
+        [sys.executable, str(ORCH), "status", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    report = json.loads(result.stdout)
+    assert report["current_phase"] == "methodology"
+    assert report["phases"]["capture"]["status"] == "done"
+    assert report["next_action"]["skill"] == "methodology"
+
+
+def test_status_complete_when_all_phases_done(tmp_path):
+    for phase in ("capture", "methodology", "testing", "standards"):
+        subprocess.check_call([
+            sys.executable, str(PHASE_STATE), "complete", str(tmp_path),
+            "--phase", phase,
+        ])
+    result = subprocess.run(
+        [sys.executable, str(ORCH), "status", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    report = json.loads(result.stdout)
+    assert report["current_phase"] is None
+    assert "complete" in report["next_action"]["summary"].lower()
+
+
+def test_help_lists_subcommands():
+    result = subprocess.run(
+        [sys.executable, str(ORCH), "--help"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert "status" in result.stdout
+    assert "parse" in result.stdout
+    assert "validate" in result.stdout

--- a/cli-anything-web-plugin/scripts/tests/test_scaffold_cli.py
+++ b/cli-anything-web-plugin/scripts/tests/test_scaffold_cli.py
@@ -1,0 +1,151 @@
+"""Tests for scaffold-cli.py: placeholder rendering, validation, and scaffolding."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+SCAFFOLD = SCRIPTS_DIR / "scaffold-cli.py"
+
+
+# --- Helpers (string conversion) ---
+
+def test_to_pascal_single_word(scaffold_cli):
+    assert scaffold_cli.to_pascal("hackernews") == "Hackernews"
+
+
+def test_to_pascal_hyphenated(scaffold_cli):
+    assert scaffold_cli.to_pascal("gh-trending") == "GhTrending"
+
+
+def test_to_pascal_underscore(scaffold_cli):
+    assert scaffold_cli.to_pascal("my_app_name") == "MyAppName"
+
+
+def test_to_upper_snake(scaffold_cli):
+    assert scaffold_cli.to_upper_snake("gh-trending") == "GH_TRENDING"
+    assert scaffold_cli.to_upper_snake("hackernews") == "HACKERNEWS"
+
+
+def test_to_underscore(scaffold_cli):
+    assert scaffold_cli.to_underscore("gh-trending") == "gh_trending"
+    assert scaffold_cli.to_underscore("hackernews") == "hackernews"
+
+
+# --- Placeholder rendering ---
+
+def test_render_string_substitutes_known_keys(scaffold_cli):
+    out = scaffold_cli.render_string("Hello ${Name}!", {"Name": "World"})
+    assert out == "Hello World!"
+
+
+def test_render_string_multiple_placeholders(scaffold_cli):
+    out = scaffold_cli.render_string(
+        "cli-web-${app_name} / ${AppName}Error",
+        {"app_name": "foo", "AppName": "Foo"},
+    )
+    assert out == "cli-web-foo / FooError"
+
+
+def test_render_string_preserves_unknown_placeholders(scaffold_cli):
+    out = scaffold_cli.render_string("Known=${A}, unknown=${B}", {"A": "yes"})
+    assert out == "Known=yes, unknown=${B}"
+
+
+# --- Placeholder detection ---
+
+def test_find_unresolved_detects_placeholders(scaffold_cli):
+    found = scaffold_cli.find_unresolved_placeholders("foo ${Bar} baz ${Quux}")
+    assert found == ["Bar", "Quux"]
+
+
+def test_find_unresolved_deduplicates(scaffold_cli):
+    found = scaffold_cli.find_unresolved_placeholders("${A} ${A} ${A}")
+    assert found == ["A"]
+
+
+def test_find_unresolved_empty_when_clean(scaffold_cli):
+    assert scaffold_cli.find_unresolved_placeholders("no placeholders") == []
+
+
+def test_find_unresolved_ignores_f_string_style(scaffold_cli):
+    # Python f-strings use {name}, not ${name}. Must not trigger.
+    assert scaffold_cli.find_unresolved_placeholders("f'{variable}'") == []
+
+
+# --- write_file / render_template validation ---
+
+def test_write_file_refuses_unresolved_content(scaffold_cli, tmp_path):
+    with pytest.raises(ValueError, match="unresolved placeholders"):
+        scaffold_cli.write_file(tmp_path / "out.py", "bad ${StillHere}")
+    assert not (tmp_path / "out.py").exists()
+
+
+def test_write_file_accepts_clean_content(scaffold_cli, tmp_path):
+    scaffold_cli.write_file(tmp_path / "ok.py", "no placeholders here\n")
+    assert (tmp_path / "ok.py").read_text() == "no placeholders here\n"
+
+
+def test_render_template_raises_when_variable_missing(scaffold_cli, tmp_path):
+    tpl = tmp_path / "fake.tpl"
+    tpl.write_text("Hello ${Missing}")
+    with pytest.raises(ValueError, match="unresolved placeholders"):
+        scaffold_cli.render_template(tpl, {})
+
+
+def test_render_template_succeeds_with_all_variables(scaffold_cli, tmp_path):
+    tpl = tmp_path / "fake.tpl"
+    tpl.write_text('name="${Name}", ver="${Ver}"')
+    out = scaffold_cli.render_template(tpl, {"Name": "foo", "Ver": "1.0"})
+    assert out == 'name="foo", ver="1.0"'
+
+
+# --- End-to-end scaffold (subprocess invocation) ---
+
+@pytest.mark.parametrize(
+    "protocol,http_client,auth_type",
+    [
+        ("rest", "httpx", "cookie"),
+        ("graphql", "httpx", "cookie"),
+        ("html-scraping", "curl_cffi", "none"),
+        ("batchexecute", "httpx", "google-sso"),
+    ],
+)
+def test_scaffold_end_to_end_no_unresolved_placeholders(
+    tmp_path, protocol, http_client, auth_type
+):
+    """Run the full scaffold pipeline; no generated file may contain ${...}."""
+    out_dir = tmp_path / "gen"
+    result = subprocess.run(
+        [
+            sys.executable, str(SCAFFOLD), str(out_dir),
+            "--app-name", "testcli",
+            "--protocol", protocol,
+            "--http-client", http_client,
+            "--auth-type", auth_type,
+            "--resources", "items",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"scaffold failed: {result.stderr}"
+
+    offenders = []
+    for path in out_dir.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        if "${" in text and any(
+            c.isalpha() or c == "_"
+            for c in text[text.index("${") + 2: text.index("${") + 3]
+        ):
+            # Stricter: re-run the detector to confirm
+            import re
+            matches = re.findall(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", text)
+            if matches:
+                offenders.append((path.name, matches))
+
+    assert not offenders, f"Unresolved placeholders: {offenders}"
+
+    # Sanity: setup.py must exist for every variant
+    assert (out_dir / "setup.py").exists()

--- a/cli-anything-web-plugin/scripts/tests/test_scaffold_cli.py
+++ b/cli-anything-web-plugin/scripts/tests/test_scaffold_cli.py
@@ -1,6 +1,7 @@
 """Tests for scaffold-cli.py: placeholder rendering, validation, and scaffolding."""
 from __future__ import annotations
 
+import py_compile
 import subprocess
 import sys
 from pathlib import Path
@@ -123,21 +124,34 @@ def test_batchexecute_client_retries_on_auth_error(tmp_path):
     assert result.returncode == 0, result.stderr
     client_src = (out_dir / "cli_web" / "beapp" / "core" / "client.py").read_text()
 
-    # Signature must expose retry_on_auth
-    assert "def _rpc(self, method: RPCMethod, params: list, retry_on_auth: bool = True)" in client_src
+    # Signature must expose retry_on_auth (new production-parity API uses rpc_id: str)
+    assert "retry_on_auth: bool = True" in client_src
     # Retry branch must call _refresh_tokens on 401/403 and recurse with retry_on_auth=False
     assert "resp.status_code in (401, 403) and retry_on_auth" in client_src
     assert "self._refresh_tokens()" in client_src
     assert "retry_on_auth=False" in client_src
+    # Must import the production-parity encoder/decoder
+    assert "from .rpc.encoder import build_url, encode_request" in client_src
+    assert "from .rpc.decoder import decode_response" in client_src
 
 
 @pytest.mark.parametrize(
     "protocol,http_client,auth_type",
     [
+        # Core protocol × client combos
         ("rest", "httpx", "cookie"),
+        ("rest", "curl_cffi", "cookie"),
+        ("rest", "httpx", "api-key"),
+        ("rest", "httpx", "none"),
         ("graphql", "httpx", "cookie"),
+        ("graphql", "curl_cffi", "cookie"),
         ("html-scraping", "curl_cffi", "none"),
+        ("html-scraping", "httpx", "none"),
+        # batchexecute typically pairs with google-sso but also works with cookie auth
         ("batchexecute", "httpx", "google-sso"),
+        ("batchexecute", "httpx", "cookie"),
+        # google-sso with REST/html-scraping (for non-batchexecute Google apps)
+        ("rest", "httpx", "google-sso"),
     ],
 )
 def test_scaffold_end_to_end_no_unresolved_placeholders(
@@ -175,3 +189,168 @@ def test_scaffold_end_to_end_no_unresolved_placeholders(
 
     # Sanity: setup.py must exist for every variant
     assert (out_dir / "setup.py").exists()
+
+    # Every generated .py file must be syntactically valid. Catches indentation
+    # hazards and quote/escape bugs in the f-string code-gen paths that the
+    # placeholder-only check misses.
+    syntax_errors = []
+    for py in out_dir.rglob("*.py"):
+        try:
+            py_compile.compile(str(py), doraise=True)
+        except py_compile.PyCompileError as exc:
+            syntax_errors.append(f"{py}: {exc}")
+    assert not syntax_errors, "Generated Python has syntax errors:\n" + "\n".join(syntax_errors)
+
+
+@pytest.mark.parametrize(
+    "has_polling,has_context,has_partial_ids",
+    [
+        (False, False, False),
+        (True, False, False),
+        (False, True, False),
+        (False, False, True),
+        (True, True, True),
+    ],
+)
+def test_scaffold_feature_flags_produce_valid_python(
+    tmp_path, has_polling, has_context, has_partial_ids
+):
+    """Each feature flag combination must emit syntactically valid helpers.py."""
+    out_dir = tmp_path / "gen"
+    flags = []
+    if has_polling:
+        flags.append("--has-polling")
+    if has_context:
+        flags.append("--has-context")
+    if has_partial_ids:
+        flags.append("--has-partial-ids")
+    result = subprocess.run(
+        [
+            sys.executable, str(SCAFFOLD), str(out_dir),
+            "--app-name", "flagtest",
+            "--protocol", "rest",
+            "--http-client", "httpx",
+            "--auth-type", "cookie",
+            "--resources", "items",
+            *flags,
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"scaffold failed: {result.stderr}"
+
+    helpers = (out_dir / "cli_web" / "flagtest" / "utils" / "helpers.py").read_text()
+    py_compile.compile(
+        str(out_dir / "cli_web" / "flagtest" / "utils" / "helpers.py"),
+        doraise=True,
+    )
+
+    assert ("def poll_until_complete" in helpers) is has_polling
+    assert ("def get_context_value" in helpers) is has_context
+    assert ("def resolve_partial_id" in helpers) is has_partial_ids
+
+
+def test_app_name_validation_rejects_numeric_start(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable, str(SCAFFOLD), str(tmp_path / "out"),
+            "--app-name", "123bad",
+            "--protocol", "rest",
+            "--http-client", "httpx",
+            "--auth-type", "none",
+            "--resources", "x",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "must start with a letter" in result.stderr or "not a valid Python" in result.stderr
+
+
+def test_app_name_validation_rejects_dots(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable, str(SCAFFOLD), str(tmp_path / "out"),
+            "--app-name", "my.app",
+            "--protocol", "rest",
+            "--http-client", "httpx",
+            "--auth-type", "none",
+            "--resources", "x",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "not a valid Python" in result.stderr
+
+
+def test_resources_must_not_be_empty(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable, str(SCAFFOLD), str(tmp_path / "out"),
+            "--app-name", "goodapp",
+            "--protocol", "rest",
+            "--http-client", "httpx",
+            "--auth-type", "none",
+            "--resources", "",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "resources" in result.stderr.lower()
+
+
+def test_google_sso_auth_has_regional_cookie_priority(tmp_path):
+    """google-sso variant must include the CLAUDE.md-mandated domain priority."""
+    out_dir = tmp_path / "gen"
+    result = subprocess.run(
+        [
+            sys.executable, str(SCAFFOLD), str(out_dir),
+            "--app-name", "gsso",
+            "--protocol", "batchexecute",
+            "--http-client", "httpx",
+            "--auth-type", "google-sso",
+            "--resources", "items",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    auth_src = (out_dir / "cli_web" / "gsso" / "core" / "auth.py").read_text()
+    # Regional cctld set + priority logic must both be present
+    assert "GOOGLE_REGIONAL_CCTLDS" in auth_src
+    assert "google.co.il" in auth_src  # spot-check one regional
+    assert 'domain == ".google.com"' in auth_src  # priority rule
+    assert "_windows_playwright_event_loop" in auth_src
+    assert "login_browser" in auth_src
+
+
+def test_cookie_auth_uses_thin_template(tmp_path):
+    """Non-google-sso auth_type should still use the thin auth.py.tpl."""
+    out_dir = tmp_path / "gen"
+    result = subprocess.run(
+        [
+            sys.executable, str(SCAFFOLD), str(out_dir),
+            "--app-name", "thin",
+            "--protocol", "rest",
+            "--http-client", "httpx",
+            "--auth-type", "cookie",
+            "--resources", "items",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    auth_src = (out_dir / "cli_web" / "thin" / "core" / "auth.py").read_text()
+    assert "GOOGLE_REGIONAL_CCTLDS" not in auth_src  # NOT the google-sso variant
+    assert "def save_auth" in auth_src
+    assert "def load_auth" in auth_src
+
+
+def test_no_config_py_generated(tmp_path):
+    """core/config.py was removed — no CLI should receive one anymore."""
+    out_dir = tmp_path / "gen"
+    subprocess.check_call([
+        sys.executable, str(SCAFFOLD), str(out_dir),
+        "--app-name", "noconfig",
+        "--protocol", "rest",
+        "--http-client", "httpx",
+        "--auth-type", "cookie",
+        "--resources", "items",
+    ])
+    assert not (out_dir / "cli_web" / "noconfig" / "core" / "config.py").exists()

--- a/cli-anything-web-plugin/scripts/tests/test_scaffold_cli.py
+++ b/cli-anything-web-plugin/scripts/tests/test_scaffold_cli.py
@@ -105,6 +105,32 @@ def test_render_template_succeeds_with_all_variables(scaffold_cli, tmp_path):
 
 # --- End-to-end scaffold (subprocess invocation) ---
 
+def test_batchexecute_client_retries_on_auth_error(tmp_path):
+    """Regression: client_batchexecute.py.tpl must wire _refresh_tokens() into
+    _rpc() on 401/403 (previously a stub method that was never called)."""
+    out_dir = tmp_path / "gen"
+    result = subprocess.run(
+        [
+            sys.executable, str(SCAFFOLD), str(out_dir),
+            "--app-name", "beapp",
+            "--protocol", "batchexecute",
+            "--http-client", "httpx",
+            "--auth-type", "google-sso",
+            "--resources", "notebooks",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    client_src = (out_dir / "cli_web" / "beapp" / "core" / "client.py").read_text()
+
+    # Signature must expose retry_on_auth
+    assert "def _rpc(self, method: RPCMethod, params: list, retry_on_auth: bool = True)" in client_src
+    # Retry branch must call _refresh_tokens on 401/403 and recurse with retry_on_auth=False
+    assert "resp.status_code in (401, 403) and retry_on_auth" in client_src
+    assert "self._refresh_tokens()" in client_src
+    assert "retry_on_auth=False" in client_src
+
+
 @pytest.mark.parametrize(
     "protocol,http_client,auth_type",
     [

--- a/cli-anything-web-plugin/scripts/tests/test_smoke_test.py
+++ b/cli-anything-web-plugin/scripts/tests/test_smoke_test.py
@@ -1,0 +1,211 @@
+"""Tests for smoke-test.py — post-install CLI validation.
+
+Focuses on the pure helpers (check_json_valid, check_leaks,
+_parse_commands_from_help) and on SmokeTest's behavior against a
+synthetic stub CLI. Doesn't require any generated CLI to be installed.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+SMOKE = SCRIPTS_DIR / "smoke-test.py"
+
+
+@pytest.fixture(scope="module")
+def smoke_mod() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("smoke_test", SMOKE)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["smoke_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- Pure helpers ---
+
+def test_check_json_valid_accepts_valid_json(smoke_mod):
+    ok, msg = smoke_mod.check_json_valid('{"a": 1}')
+    assert ok is True
+    assert msg == ""
+
+
+def test_check_json_valid_rejects_malformed(smoke_mod):
+    ok, msg = smoke_mod.check_json_valid('{bad')
+    assert ok is False
+    assert "Invalid JSON" in msg
+
+
+def test_check_json_valid_rejects_empty(smoke_mod):
+    ok, msg = smoke_mod.check_json_valid("")
+    assert ok is False
+    assert "Empty" in msg
+
+
+def test_check_json_valid_strips_whitespace(smoke_mod):
+    ok, _ = smoke_mod.check_json_valid('   \n{"ok": true}\n  ')
+    assert ok is True
+
+
+# --- Leak detection ---
+
+def test_check_leaks_detects_batchexecute_wrb(smoke_mod):
+    # Actual leak: raw batchexecute array bleeds through as-is, unescaped.
+    leaks = smoke_mod.check_leaks('[["wrb.fr","xyz",""]]')
+    assert any("wrb.fr" in leak for leak in leaks)
+
+
+def test_check_leaks_detects_csrf_token_leak(smoke_mod):
+    leaks = smoke_mod.check_leaks('{"SNlM0e": "abc123"}')
+    assert any("CSRF" in leak for leak in leaks)
+
+
+def test_check_leaks_detects_session_id(smoke_mod):
+    leaks = smoke_mod.check_leaks('{"FdrFJe": "-123"}')
+    assert any("Session ID" in leak for leak in leaks)
+
+
+def test_check_leaks_clean_output(smoke_mod):
+    leaks = smoke_mod.check_leaks('{"success": true, "data": {"items": [1, 2, 3]}}')
+    assert leaks == []
+
+
+def test_check_leaks_returns_multiple_when_present(smoke_mod):
+    mixed = '"wrb.fr" and "SNlM0e" in one string'
+    leaks = smoke_mod.check_leaks(mixed)
+    # Should flag both
+    assert len(leaks) >= 2
+
+
+# --- Help parsing ---
+
+def test_parse_commands_extracts_click_subcommands(smoke_mod):
+    help_output = """Usage: cli-web-foo [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  feed       Browse posts
+  search     Search items
+  auth       Auth management
+"""
+    names = smoke_mod.SmokeTest._parse_commands_from_help(help_output)
+    assert names == ["feed", "search", "auth"]
+
+
+def test_parse_commands_empty_on_flat_cli(smoke_mod):
+    names = smoke_mod.SmokeTest._parse_commands_from_help("Usage: foo\n  --help\n")
+    assert names == []
+
+
+def test_parse_commands_stops_at_blank_line(smoke_mod):
+    help_output = """Commands:
+  first
+  second
+
+  not_a_command
+"""
+    names = smoke_mod.SmokeTest._parse_commands_from_help(help_output)
+    assert names == ["first", "second"]
+
+
+# --- run_cli error paths ---
+
+def test_run_cli_reports_missing_binary(smoke_mod):
+    code, out, err = smoke_mod.run_cli(["/nonexistent/cli-web-xxxxx"], ["--help"])
+    assert code == -2
+    assert "not found" in err
+
+
+def test_run_cli_timeout_path(smoke_mod, tmp_path):
+    """A deliberately slow script should trip the timeout branch."""
+    slow = tmp_path / "slow.py"
+    slow.write_text("import time; time.sleep(30)\n")
+    code, out, err = smoke_mod.run_cli([sys.executable, str(slow)], [], timeout=1)
+    assert code == -1
+    assert err == "TIMEOUT"
+
+
+def test_run_cli_captures_stdout_stderr(smoke_mod, tmp_path):
+    script = tmp_path / "echo.py"
+    script.write_text(
+        "import sys; print('hello-stdout'); print('warn', file=sys.stderr)\n"
+    )
+    code, out, err = smoke_mod.run_cli([sys.executable, str(script)], [])
+    assert code == 0
+    assert "hello-stdout" in out
+    assert "warn" in err
+
+
+# --- SmokeTest class behavior (using a fake CLI) ---
+
+@pytest.fixture
+def fake_cli(tmp_path):
+    """Create a tiny executable script that mimics a Click CLI with
+    --help, --version, and one JSON-returning subcommand."""
+    cli = tmp_path / "cli-web-fake"
+    cli.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "args = sys.argv[1:]\n"
+        "if args == ['--help']:\n"
+        "    print('Usage: cli-web-fake [OPTIONS] COMMAND')\n"
+        "    print('Commands:')\n"
+        "    print('  hello    Say hi')\n"
+        "    sys.exit(0)\n"
+        "if args == ['--version']:\n"
+        "    print('cli-web-fake 0.1.0')\n"
+        "    sys.exit(0)\n"
+        "if args == ['hello', '--json']:\n"
+        "    print('{\"success\": true, \"data\": \"hi\"}')\n"
+        "    sys.exit(0)\n"
+        "sys.exit(2)\n"
+    )
+    cli.chmod(cli.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return cli
+
+
+def test_smoke_test_resolves_cli_via_path(smoke_mod, fake_cli, monkeypatch):
+    """resolve_cli() should find the fake CLI via shutil.which when it's on PATH."""
+    monkeypatch.setenv("PATH", f"{fake_cli.parent}{os.pathsep}{os.environ.get('PATH', '')}")
+    st = smoke_mod.SmokeTest("cli-web-fake", auth_type="none", skip_auth=True)
+    assert st.resolve_cli() is True
+    assert st.cli_cmd[0].endswith("cli-web-fake")
+
+
+def test_smoke_test_check_help_marks_pass(smoke_mod, fake_cli, monkeypatch):
+    monkeypatch.setenv("PATH", f"{fake_cli.parent}{os.pathsep}{os.environ.get('PATH', '')}")
+    st = smoke_mod.SmokeTest("cli-web-fake", auth_type="none", skip_auth=True)
+    assert st.resolve_cli()
+    st.check_help()
+    assert any(r["name"] == "--help responds" and r["status"] == "pass" for r in st.results)
+
+
+def test_smoke_test_check_version_marks_pass(smoke_mod, fake_cli, monkeypatch):
+    monkeypatch.setenv("PATH", f"{fake_cli.parent}{os.pathsep}{os.environ.get('PATH', '')}")
+    st = smoke_mod.SmokeTest("cli-web-fake", auth_type="none", skip_auth=True)
+    assert st.resolve_cli()
+    st.check_version()
+    assert any(r["name"] == "--version responds" and r["status"] == "pass" for r in st.results)
+
+
+def test_smoke_test_discover_commands_finds_subcommand(smoke_mod, fake_cli, monkeypatch):
+    monkeypatch.setenv("PATH", f"{fake_cli.parent}{os.pathsep}{os.environ.get('PATH', '')}")
+    st = smoke_mod.SmokeTest("cli-web-fake", auth_type="none", skip_auth=True)
+    assert st.resolve_cli()
+    st.check_help()
+    assert "hello" in st.discover_commands()
+
+
+def test_smoke_test_missing_cli_reports_fail(smoke_mod):
+    st = smoke_mod.SmokeTest("cli-web-does-not-exist-anywhere", auth_type="none", skip_auth=True)
+    assert st.resolve_cli() is False
+    assert any(r["status"] == "fail" for r in st.results)

--- a/cli-anything-web-plugin/scripts/tests/test_state_utils.py
+++ b/cli-anything-web-plugin/scripts/tests/test_state_utils.py
@@ -1,0 +1,51 @@
+"""Tests for state_utils.py — shared JSON-state I/O."""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import state_utils  # noqa: E402
+
+
+def test_utc_now_iso_format():
+    value = state_utils.utc_now_iso()
+    # ISO-8601 UTC: "YYYY-MM-DDTHH:MM:SS.microseconds+00:00"
+    assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*\+00:00$", value)
+
+
+def test_load_json_state_returns_default_when_missing(tmp_path):
+    path = tmp_path / "missing.json"
+    default = {"hello": "world"}
+    assert state_utils.load_json_state(path, default=default) == default
+
+
+def test_load_json_state_returns_none_when_missing_no_default(tmp_path):
+    assert state_utils.load_json_state(tmp_path / "missing.json") is None
+
+
+def test_save_and_reload_round_trip(tmp_path):
+    path = tmp_path / "state.json"
+    state_utils.save_json_state(path, {"phase": "capture", "status": "done"})
+    loaded = state_utils.load_json_state(path)
+    assert loaded["phase"] == "capture"
+    assert loaded["status"] == "done"
+    assert "updated_at" in loaded  # stamped on save
+
+
+def test_save_creates_parent_dirs(tmp_path):
+    path = tmp_path / "deep" / "nested" / "state.json"
+    state_utils.save_json_state(path, {"x": 1})
+    assert path.exists()
+
+
+def test_save_stamps_updated_at(tmp_path):
+    path = tmp_path / "state.json"
+    s = {"a": 1}
+    state_utils.save_json_state(path, s)
+    assert "updated_at" in s  # mutates in place

--- a/cli-anything-web-plugin/scripts/tests/test_traffic_utils.py
+++ b/cli-anything-web-plugin/scripts/tests/test_traffic_utils.py
@@ -43,6 +43,30 @@ def test_is_static_asset_rejects_api():
     assert traffic_utils.is_static_asset("https://api.example.com/v1/users") is False
 
 
+def test_is_static_asset_default_preserves_media_api_endpoints():
+    """Music-streaming APIs like /songs/123.mp3 must NOT be filtered by default."""
+    assert traffic_utils.is_static_asset("https://api.music.com/songs/123.mp3") is False
+    assert traffic_utils.is_static_asset("https://api.example.com/videos/1.mp4") is False
+
+
+def test_is_static_asset_include_media_filters_media():
+    """With include_media=True (real-time capture), media IS filtered."""
+    assert traffic_utils.is_static_asset("https://cdn.example.com/clip.mp4", include_media=True) is True
+    assert traffic_utils.is_static_asset("https://cdn.example.com/audio.mp3", include_media=True) is True
+
+
+def test_is_noise_url_handles_none():
+    assert traffic_utils.is_noise_url(None) is False
+
+
+def test_is_noise_url_handles_empty_string():
+    assert traffic_utils.is_noise_url("") is False
+
+
+def test_is_static_asset_handles_empty_string():
+    assert traffic_utils.is_static_asset("") is False
+
+
 def test_normalize_headers_dict_pass_through():
     assert traffic_utils.normalize_headers({"A": "1"}) == {"A": "1"}
 

--- a/cli-anything-web-plugin/scripts/tests/test_traffic_utils.py
+++ b/cli-anything-web-plugin/scripts/tests/test_traffic_utils.py
@@ -1,0 +1,63 @@
+"""Tests for traffic_utils.py — shared noise/static/header helpers."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import traffic_utils  # noqa: E402
+
+
+def test_is_noise_google_analytics():
+    assert traffic_utils.is_noise_url("https://google-analytics.com/collect") is True
+
+
+def test_is_noise_facebook_tracking():
+    assert traffic_utils.is_noise_url("https://facebook.com/tr?id=1") is True
+
+
+def test_is_noise_datadog():
+    assert traffic_utils.is_noise_url("https://browser-intake-datadoghq.com/api/v2/rum") is True
+
+
+def test_is_noise_rejects_real_api():
+    assert traffic_utils.is_noise_url("https://api.example.com/v1/users") is False
+    assert traffic_utils.is_noise_url("https://example.com/graphql") is False
+
+
+def test_is_static_asset_by_extension():
+    assert traffic_utils.is_static_asset("https://cdn.example.com/app.js") is True
+    assert traffic_utils.is_static_asset("https://cdn.example.com/style.css") is True
+    assert traffic_utils.is_static_asset("https://cdn.example.com/logo.png") is True
+
+
+def test_is_static_asset_strips_query_and_fragment():
+    assert traffic_utils.is_static_asset("https://cdn.example.com/app.js?v=123") is True
+    assert traffic_utils.is_static_asset("https://cdn.example.com/app.js#section") is True
+
+
+def test_is_static_asset_rejects_api():
+    assert traffic_utils.is_static_asset("https://api.example.com/v1/users") is False
+
+
+def test_normalize_headers_dict_pass_through():
+    assert traffic_utils.normalize_headers({"A": "1"}) == {"A": "1"}
+
+
+def test_normalize_headers_list_format():
+    playwright = [{"name": "A", "value": "1"}, {"name": "B", "value": "2"}]
+    assert traffic_utils.normalize_headers(playwright) == {"A": "1", "B": "2"}
+
+
+def test_normalize_headers_none_returns_empty():
+    assert traffic_utils.normalize_headers(None) == {}
+
+
+def test_noise_patterns_compiled_once():
+    # Sanity: NOISE_PATTERNS must be pre-compiled regex objects, not strings.
+    import re
+    assert all(isinstance(p, re.Pattern) for p in traffic_utils.NOISE_PATTERNS)
+    assert len(traffic_utils.NOISE_PATTERNS) > 20  # merged list is substantial

--- a/cli-anything-web-plugin/scripts/tests/test_validate_capture.py
+++ b/cli-anything-web-plugin/scripts/tests/test_validate_capture.py
@@ -1,0 +1,158 @@
+"""Tests for validate-capture.py — Phase-1 output validation."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+VALIDATE = SCRIPTS_DIR / "validate-capture.py"
+
+
+def _write_capture(app_dir: Path, entries: list[dict], analysis: dict | None = None) -> None:
+    capture_dir = app_dir / "traffic-capture"
+    capture_dir.mkdir(parents=True, exist_ok=True)
+    (capture_dir / "raw-traffic.json").write_text(json.dumps(entries))
+    if analysis is not None:
+        (capture_dir / "traffic-analysis.json").write_text(json.dumps(analysis))
+
+
+def _entry(
+    url: str = "https://api.example.com/v1/items",
+    method: str = "GET",
+    status: int = 200,
+    mime: str = "application/json",
+    body: object = None,
+) -> dict:
+    return {
+        "url": url,
+        "method": method,
+        "status": status,
+        "mime_type": mime,
+        "response_body": body if body is not None else {"ok": True},
+    }
+
+
+def _run(app_dir: Path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(VALIDATE), str(app_dir), "--json", *extra],
+        capture_output=True,
+        text=True,
+    )
+
+
+# --- Happy paths ---
+
+def test_passes_on_healthy_capture(tmp_path):
+    entries = [
+        _entry(f"https://api.example.com/v1/items/{i}")
+        for i in range(20)
+    ] + [_entry(method="POST", url="https://api.example.com/v1/items")]
+    analysis = {"protocol": {"protocol": "rest", "confidence": 90}}
+    _write_capture(tmp_path, entries, analysis)
+
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout
+    report = json.loads(result.stdout)
+    assert report["overall"] == "pass"
+
+
+def test_read_only_flag_skips_write_check(tmp_path):
+    entries = [_entry(f"https://api.example.com/v1/items/{i}") for i in range(20)]
+    analysis = {"protocol": {"protocol": "rest", "confidence": 90}}
+    _write_capture(tmp_path, entries, analysis)
+
+    result = _run(tmp_path, "--read-only")
+    assert result.returncode == 0
+    report = json.loads(result.stdout)
+    write = next(c for c in report["checks"] if c["name"] == "write_ops")
+    assert write["status"] == "pass"
+
+
+# --- Blocking failures ---
+
+def test_fails_on_empty_capture(tmp_path):
+    _write_capture(tmp_path, [])
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert report["overall"] == "fail"
+    entry_check = next(c for c in report["checks"] if c["name"] == "entry_count")
+    assert entry_check["status"] == "fail"
+
+
+def test_fails_on_sparse_capture(tmp_path):
+    entries = [_entry() for _ in range(5)]
+    _write_capture(tmp_path, entries, {"protocol": {"protocol": "rest", "confidence": 80}})
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    entry_check = next(c for c in report["checks"] if c["name"] == "entry_count")
+    assert entry_check["status"] == "fail"
+
+
+def test_fails_on_unknown_protocol(tmp_path):
+    entries = [_entry(f"https://api.example.com/v1/items/{i}") for i in range(20)]
+    entries.append(_entry(method="POST"))
+    _write_capture(tmp_path, entries, {"protocol": {"protocol": "unknown", "confidence": 0}})
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert any(c["name"] == "protocol" and c["status"] == "fail" for c in report["checks"])
+
+
+def test_fails_on_missing_write_ops(tmp_path):
+    entries = [_entry(f"https://api.example.com/v1/items/{i}") for i in range(20)]
+    _write_capture(tmp_path, entries, {"protocol": {"protocol": "rest", "confidence": 90}})
+    result = _run(tmp_path)  # no --read-only
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert any(c["name"] == "write_ops" and c["status"] == "fail" for c in report["checks"])
+
+
+def test_fails_on_dominant_errors(tmp_path):
+    entries = [_entry(status=401) for _ in range(20)]
+    entries.append(_entry(method="POST", status=401))
+    _write_capture(tmp_path, entries, {"protocol": {"protocol": "rest", "confidence": 80}})
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert any(c["name"] == "error_rate" and c["status"] == "fail" for c in report["checks"])
+
+
+def test_fails_on_low_endpoint_diversity(tmp_path):
+    # 20 hits against a single URL — passes count but flat
+    entries = [_entry() for _ in range(20)] + [_entry(method="POST")]
+    _write_capture(tmp_path, entries, {"protocol": {"protocol": "rest", "confidence": 90}})
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert any(
+        c["name"] == "endpoint_diversity" and c["status"] == "fail"
+        for c in report["checks"]
+    )
+
+
+# --- Missing inputs ---
+
+def test_exit_code_2_when_raw_traffic_missing(tmp_path):
+    result = _run(tmp_path)
+    assert result.returncode == 2
+    assert "not found" in result.stderr
+
+
+def test_handles_missing_analysis_gracefully(tmp_path):
+    """raw-traffic.json present, traffic-analysis.json missing — should still run."""
+    entries = [_entry(f"https://api.example.com/v1/items/{i}") for i in range(20)]
+    entries.append(_entry(method="POST"))
+    capture_dir = tmp_path / "traffic-capture"
+    capture_dir.mkdir(parents=True)
+    (capture_dir / "raw-traffic.json").write_text(json.dumps(entries))
+
+    result = _run(tmp_path)
+    # Protocol check will fail because analysis is empty
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    proto = next(c for c in report["checks"] if c["name"] == "protocol")
+    assert proto["status"] == "fail"

--- a/cli-anything-web-plugin/scripts/tests/test_validate_checklist.py
+++ b/cli-anything-web-plugin/scripts/tests/test_validate_checklist.py
@@ -1,0 +1,216 @@
+"""Tests for validate-checklist.py — the 65-point quality gate.
+
+Two test styles:
+1. End-to-end via subprocess against scaffolded CLIs (realistic).
+2. Synthetic minimal harnesses that trigger specific checks in isolation
+   (catches regressions on individual check IDs).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+VALIDATE = SCRIPTS_DIR / "validate-checklist.py"
+SCAFFOLD = SCRIPTS_DIR / "scaffold-cli.py"
+
+
+def _validate(harness: Path, app_name: str, auth_type: str = "cookie") -> dict:
+    """Run the validator in --json mode and return the parsed report."""
+    result = subprocess.run(
+        [
+            sys.executable, str(VALIDATE), str(harness),
+            "--app-name", app_name,
+            "--auth-type", auth_type,
+            "--json",
+        ],
+        capture_output=True, text=True,
+    )
+    # Non-zero exit is normal when there are failures — we parse anyway.
+    assert result.stdout, f"no stdout; stderr: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+def _check(report: dict, check_id: str) -> dict:
+    """Return the single check entry matching check_id."""
+    for entry in report["checks"]:
+        if entry["id"] == check_id:
+            return entry
+    raise AssertionError(f"check id {check_id!r} not found in report")
+
+
+# --- Fixture: freshly scaffolded CLI (incomplete but structurally valid) ---
+
+@pytest.fixture(scope="module")
+def scaffolded_harness(tmp_path_factory):
+    harness = tmp_path_factory.mktemp("harness") / "agent-harness"
+    subprocess.check_call([
+        sys.executable, str(SCAFFOLD), str(harness),
+        "--app-name", "vcapp",
+        "--protocol", "rest",
+        "--http-client", "httpx",
+        "--auth-type", "cookie",
+        "--resources", "items",
+    ])
+    return harness
+
+
+def test_scaffolded_cli_has_correct_directory_structure(scaffolded_harness):
+    """Check 1.1, 1.3, 1.4, 1.5 — structural correctness of scaffold output."""
+    report = _validate(scaffolded_harness, "vcapp")
+    assert _check(report, "1.1")["status"] == "pass"  # cli_web/<app>/ exists
+    assert _check(report, "1.3")["status"] == "pass"  # NO cli_web/__init__.py
+    assert _check(report, "1.4")["status"] == "pass"  # <app>/__init__.py present
+    assert _check(report, "1.5")["status"] == "pass"  # core/commands/utils/tests all there
+
+
+def test_scaffolded_cli_has_required_files(scaffolded_harness):
+    """Check 2.x — required files from scaffold."""
+    report = _validate(scaffolded_harness, "vcapp")
+    assert _check(report, "2.1")["status"] == "pass"  # <app>_cli.py
+    assert _check(report, "2.2")["status"] == "pass"  # __main__.py
+    assert _check(report, "2.3")["status"] == "pass"  # core/client.py
+    assert _check(report, "2.4")["status"] == "pass"  # core/exceptions.py
+    assert _check(report, "2.5")["status"] == "pass"  # core/auth.py (auth_type=cookie)
+    assert _check(report, "2.8")["status"] == "pass"  # utils/repl_skin.py
+    assert _check(report, "2.9")["status"] == "pass"  # utils/output.py
+
+
+def test_scaffolded_auth_none_skips_auth_file_check(tmp_path):
+    """For --auth-type none, check 2.5 should report N/A, not FAIL."""
+    harness = tmp_path / "no-auth"
+    subprocess.check_call([
+        sys.executable, str(SCAFFOLD), str(harness),
+        "--app-name", "noauth",
+        "--protocol", "rest",
+        "--http-client", "httpx",
+        "--auth-type", "none",
+        "--resources", "x",
+    ])
+    report = _validate(harness, "noauth", auth_type="none")
+    assert _check(report, "2.5")["status"] == "na"
+
+
+def test_json_output_includes_summary_counts(scaffolded_harness):
+    report = _validate(scaffolded_harness, "vcapp")
+    assert "summary" in report
+    for key in ("pass", "fail", "skip", "na"):
+        assert key in report["summary"]
+        assert isinstance(report["summary"][key], int)
+    # At least one pass and some meaningful volume of checks
+    assert report["summary"]["pass"] > 10
+    assert len(report["checks"]) >= 40
+
+
+def test_validator_reports_app_name_and_auth_type(scaffolded_harness):
+    report = _validate(scaffolded_harness, "vcapp")
+    assert report["app_name"] == "vcapp"
+    assert report["auth_type"] == "cookie"
+
+
+# --- Synthetic failure detection ---
+
+def _make_minimal_harness(tmp_path: Path, app_name: str = "tapp",
+                          auth_type: str = "cookie") -> Path:
+    """Create a minimal valid harness so we can mutate it per test."""
+    harness = tmp_path / "harness"
+    subprocess.check_call([
+        sys.executable, str(SCAFFOLD), str(harness),
+        "--app-name", app_name,
+        "--protocol", "rest",
+        "--http-client", "httpx",
+        "--auth-type", auth_type,
+        "--resources", "items",
+    ])
+    return harness
+
+
+def test_detects_missing_sub_package_init(tmp_path):
+    """Check 1.4 must fail when <app>/__init__.py is deleted."""
+    harness = _make_minimal_harness(tmp_path)
+    init = harness / "cli_web" / "tapp" / "__init__.py"
+    init.unlink()
+    report = _validate(harness, "tapp")
+    assert _check(report, "1.4")["status"] == "fail"
+
+
+def test_detects_stray_namespace_init(tmp_path):
+    """Check 1.3 must fail when cli_web/__init__.py exists (breaks namespace pkg)."""
+    harness = _make_minimal_harness(tmp_path)
+    (harness / "cli_web" / "__init__.py").write_text("# oops\n")
+    report = _validate(harness, "tapp")
+    assert _check(report, "1.3")["status"] == "fail"
+
+
+def test_detects_missing_required_directory(tmp_path):
+    """Check 1.5 — removing tests/ must fail the all-dirs check."""
+    harness = _make_minimal_harness(tmp_path)
+    tests = harness / "cli_web" / "tapp" / "tests"
+    for child in tests.iterdir():
+        child.unlink()
+    tests.rmdir()
+    report = _validate(harness, "tapp")
+    assert _check(report, "1.5")["status"] == "fail"
+
+
+def test_detects_missing_setup_py(tmp_path):
+    """Check 1.6 fails when setup.py is missing."""
+    harness = _make_minimal_harness(tmp_path)
+    (harness / "setup.py").unlink()
+    report = _validate(harness, "tapp")
+    assert _check(report, "1.6")["status"] == "fail"
+
+
+def test_detects_missing_core_client(tmp_path):
+    """Check 2.3 fails when core/client.py is missing."""
+    harness = _make_minimal_harness(tmp_path)
+    (harness / "cli_web" / "tapp" / "core" / "client.py").unlink()
+    report = _validate(harness, "tapp")
+    assert _check(report, "2.3")["status"] == "fail"
+
+
+def test_detects_missing_auth_when_required(tmp_path):
+    """Check 2.5 fails when auth_type != none but auth.py is absent."""
+    harness = _make_minimal_harness(tmp_path, auth_type="cookie")
+    (harness / "cli_web" / "tapp" / "core" / "auth.py").unlink()
+    report = _validate(harness, "tapp", auth_type="cookie")
+    assert _check(report, "2.5")["status"] == "fail"
+
+
+# --- Error handling / argparse ---
+
+def test_rejects_non_existent_harness_dir(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable, str(VALIDATE), str(tmp_path / "nonexistent"),
+            "--app-name", "x", "--json",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "not a directory" in result.stderr
+
+
+def test_rejects_unknown_auth_type(scaffolded_harness):
+    result = subprocess.run(
+        [
+            sys.executable, str(VALIDATE), str(scaffolded_harness),
+            "--app-name", "vcapp", "--auth-type", "oauth",
+            "--json",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+
+
+def test_run_without_app_name_errors(tmp_path):
+    harness = _make_minimal_harness(tmp_path)
+    result = subprocess.run(
+        [sys.executable, str(VALIDATE), str(harness), "--json"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0

--- a/cli-anything-web-plugin/scripts/traffic_utils.py
+++ b/cli-anything-web-plugin/scripts/traffic_utils.py
@@ -13,10 +13,17 @@ from __future__ import annotations
 
 import re
 
-# File extensions treated as static assets (not API traffic).
+# Web-static assets (fonts, images, JS, CSS, source maps) — never useful
+# as API endpoints. Safe to filter aggressively.
 STATIC_EXTENSIONS: frozenset[str] = frozenset((
     ".js", ".css", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico",
     ".woff", ".woff2", ".ttf", ".eot", ".map", ".webp", ".avif",
+))
+
+# Media extensions — kept SEPARATE because some APIs legitimately serve
+# these as endpoint paths (e.g., a music streaming API returning /songs/123.mp3
+# with `application/json` metadata). Callers opt in to filtering these.
+MEDIA_EXTENSIONS: frozenset[str] = frozenset((
     ".mp4", ".webm", ".mp3", ".ogg",
 ))
 
@@ -143,15 +150,31 @@ NOISE_PATTERNS: list[re.Pattern[str]] = [
 ]
 
 
-def is_noise_url(url: str) -> bool:
-    """Return True if a URL matches any noise pattern (ads/tracking/CDN)."""
+def is_noise_url(url: str | None) -> bool:
+    """Return True if a URL matches any noise pattern (ads/tracking/CDN).
+
+    Returns False for None or empty string — a missing URL is not noise,
+    it's a malformed entry the caller should handle separately.
+    """
+    if not url:
+        return False
     return any(p.search(url) for p in NOISE_PATTERNS)
 
 
-def is_static_asset(url: str) -> bool:
-    """Return True if a URL points to a static asset by file extension."""
+def is_static_asset(url: str, include_media: bool = False) -> bool:
+    """Return True if a URL points to a static asset by file extension.
+
+    By default only checks `STATIC_EXTENSIONS` (web-static). Pass
+    `include_media=True` to also treat MEDIA_EXTENSIONS (.mp3/.mp4/.webm/.ogg)
+    as static — appropriate for real-time capture where media is usually noise,
+    but NOT appropriate for offline trace parsing where a music-streaming API
+    might legitimately serve an endpoint with a media extension.
+    """
+    if not url:
+        return False
     path = url.split("?")[0].split("#")[0]
-    return any(path.endswith(ext) for ext in STATIC_EXTENSIONS)
+    extensions = STATIC_EXTENSIONS | MEDIA_EXTENSIONS if include_media else STATIC_EXTENSIONS
+    return any(path.endswith(ext) for ext in extensions)
 
 
 def normalize_headers(headers) -> dict:

--- a/cli-anything-web-plugin/scripts/traffic_utils.py
+++ b/cli-anything-web-plugin/scripts/traffic_utils.py
@@ -1,0 +1,173 @@
+"""Shared traffic-analysis helpers for capture + analysis scripts.
+
+Merged from the previous independent implementations in mitmproxy-capture.py
+(compiled-regex noise filter) and analyze-traffic.py (substring noise filter).
+The compiled-regex approach is ~10x faster on large traces and is used here.
+
+Consumers:
+    - parse-trace.py (static-asset filtering)
+    - analyze-traffic.py (noise filtering + header normalization)
+    - mitmproxy-capture.py (real-time noise filtering)
+"""
+from __future__ import annotations
+
+import re
+
+# File extensions treated as static assets (not API traffic).
+STATIC_EXTENSIONS: frozenset[str] = frozenset((
+    ".js", ".css", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico",
+    ".woff", ".woff2", ".ttf", ".eot", ".map", ".webp", ".avif",
+    ".mp4", ".webm", ".mp3", ".ogg",
+))
+
+# Noise URL patterns — analytics, tracking, ad networks, CDN endpoints.
+# Compiled once at import; cheap to call many times per entry.
+#
+# Keep organized by category — any new pattern should be added to the right
+# section so maintainers can see the full taxonomy at a glance.
+NOISE_PATTERNS: list[re.Pattern[str]] = [
+    # --- Google analytics / ads ---
+    re.compile(r"google-analytics\.com", re.I),
+    re.compile(r"analytics\.google\.com", re.I),
+    re.compile(r"googletagmanager\.com", re.I),
+    re.compile(r"googlesyndication\.com", re.I),
+    re.compile(r"googleadservices\.com", re.I),
+    re.compile(r"doubleclick\.net", re.I),
+    re.compile(r"google\.com/pagead", re.I),
+    re.compile(r"google\.com/ads", re.I),
+    re.compile(r"www\.google\.co\.", re.I),
+    re.compile(r"gstatic\.com", re.I),
+    re.compile(r"googleapis\.com/css", re.I),
+    re.compile(r"fonts\.googleapis\.com", re.I),
+    re.compile(r"fonts\.gstatic\.com", re.I),
+    re.compile(r"play\.google\.com/log", re.I),
+    re.compile(r"signaler-pa\.clients6", re.I),
+    re.compile(r"accounts\.google\.com/gsi/", re.I),
+    re.compile(r"apis\.google\.com", re.I),
+    re.compile(r"adtrafficquality\.google", re.I),
+
+    # --- Cloudflare ---
+    re.compile(r"cdn-cgi/", re.I),
+    re.compile(r"cloudflareinsights", re.I),
+    re.compile(r"static\.cloudflareinsights", re.I),
+    re.compile(r"cdn-cgi/rum", re.I),
+    re.compile(r"cdn-cgi/challenge-platform", re.I),
+
+    # --- Social / trackers ---
+    re.compile(r"facebook\.net", re.I),
+    re.compile(r"facebook\.com/tr", re.I),
+    re.compile(r"connect\.facebook", re.I),
+    re.compile(r"analytics\.twitter\.com", re.I),
+    re.compile(r"ads-twitter\.com", re.I),
+    re.compile(r"twitter\.com", re.I),
+
+    # --- Ad networks / programmatic advertising ---
+    re.compile(r"taboola\.com", re.I),
+    re.compile(r"outbrain\.com", re.I),
+    re.compile(r"optable\.co", re.I),
+    re.compile(r"admedo\.com", re.I),
+    re.compile(r"scorecardresearch\.com", re.I),
+    re.compile(r"statcounter\.com", re.I),
+    re.compile(r"liftdsp\.com", re.I),
+    re.compile(r"bidr\.io", re.I),
+    re.compile(r"cnv\.event\.prod", re.I),
+    re.compile(r"rubiconproject\.com", re.I),
+    re.compile(r"criteo\.com", re.I),
+    re.compile(r"adnxs\.com", re.I),
+    re.compile(r"adsrvr\.org", re.I),
+    re.compile(r"sharethrough\.com", re.I),
+    re.compile(r"3lift\.com", re.I),
+    re.compile(r"liadm\.com", re.I),
+    re.compile(r"id5-sync\.com", re.I),
+    re.compile(r"casalemedia\.com", re.I),
+    re.compile(r"kargo\.com", re.I),
+    re.compile(r"unrulymedia\.com", re.I),
+    re.compile(r"lngtd\.com", re.I),
+    re.compile(r"creativecdn\.com", re.I),
+    re.compile(r"moatads\.com", re.I),
+    re.compile(r"amazon-adsystem\.com", re.I),
+    re.compile(r"pubmatic\.com", re.I),
+    re.compile(r"openx\.net", re.I),
+    re.compile(r"indexww\.com", re.I),
+    re.compile(r"hadron\.ad\.gt", re.I),
+
+    # --- Monitoring / analytics SDKs ---
+    re.compile(r"segment\.io", re.I),
+    re.compile(r"segment\.com/v1", re.I),
+    re.compile(r"segment\.prod", re.I),
+    re.compile(r"amplitude\.com", re.I),
+    re.compile(r"mixpanel\.com", re.I),
+    re.compile(r"hotjar\.com", re.I),
+    re.compile(r"clarity\.ms", re.I),
+    re.compile(r"sentry\.io/api", re.I),
+    re.compile(r"datadoghq\.com", re.I),
+    re.compile(r"rum-http-intake", re.I),
+    re.compile(r"browser-intake-datadoghq", re.I),
+    re.compile(r"newrelic\.com", re.I),
+    re.compile(r"nr-data\.net", re.I),
+    re.compile(r"fullstory\.com", re.I),
+
+    # --- CRM / marketing automation ---
+    re.compile(r"hubspot\.com", re.I),
+    re.compile(r"hscollectedforms\.net", re.I),
+    re.compile(r"hsforms\.com", re.I),
+    re.compile(r"cookiebot\.com", re.I),
+    re.compile(r"cookielaw\.org", re.I),
+    re.compile(r"onetrust\.com", re.I),
+    re.compile(r"intercom\.io", re.I),
+    re.compile(r"crisp\.chat", re.I),
+    re.compile(r"zendesk\.com", re.I),
+    re.compile(r"/ht/event", re.I),
+    re.compile(r"/hubspot", re.I),
+
+    # --- Fonts / CDN ---
+    re.compile(r"fontawesome\.com", re.I),
+
+    # --- GitHub internal ---
+    re.compile(r"avatars\.githubusercontent\.com", re.I),
+    re.compile(r"collector\.github\.com", re.I),
+    re.compile(r"api\.github\.com/_private", re.I),
+
+    # --- Generic beacon / pixel / rum ---
+    re.compile(r"/beacon", re.I),
+    re.compile(r"/pixel", re.I),
+    re.compile(r"/collect\b", re.I),
+    re.compile(r"/rum", re.I),
+    re.compile(r"/manifest\.json", re.I),
+
+    # --- Site-specific tracking (non-API endpoints) ---
+    re.compile(r"slinksuggestion\.com", re.I),
+    re.compile(r"drainpaste\.com", re.I),
+    re.compile(r"e\.producthunt\.com", re.I),
+    re.compile(r"t\.producthunt\.com", re.I),
+]
+
+
+def is_noise_url(url: str) -> bool:
+    """Return True if a URL matches any noise pattern (ads/tracking/CDN)."""
+    return any(p.search(url) for p in NOISE_PATTERNS)
+
+
+def is_static_asset(url: str) -> bool:
+    """Return True if a URL points to a static asset by file extension."""
+    path = url.split("?")[0].split("#")[0]
+    return any(path.endswith(ext) for ext in STATIC_EXTENSIONS)
+
+
+def normalize_headers(headers) -> dict:
+    """Normalize headers to flat {name: value} dict.
+
+    Accepts:
+        - dict (mitmproxy, already flat)
+        - list of {name, value} dicts (playwright trace format)
+        - None (returns {})
+    """
+    if isinstance(headers, dict):
+        return headers
+    if isinstance(headers, list):
+        return {
+            h.get("name", ""): h.get("value", "")
+            for h in headers
+            if isinstance(h, dict)
+        }
+    return {}

--- a/cli-anything-web-plugin/scripts/validate-capture.py
+++ b/cli-anything-web-plugin/scripts/validate-capture.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Validate a Phase-1 capture before handing off to Phase 2 (methodology).
+
+Reads raw-traffic.json and traffic-analysis.json for a CLI app and runs the
+checks that should be verified before marking capture complete. Bad captures
+produce broken generated CLIs — this script catches the common failure modes:
+
+- Sparse capture (too few entries; user browsed too little)
+- Unknown protocol (analyzer couldn't classify — missing or scrambled traffic)
+- No WRITE operations (CRUD site without any POST/PUT/DELETE captured)
+- Truncated bodies (response_body missing on large responses)
+- Dominant error responses (mostly 4xx/5xx means capture was broken)
+
+Usage:
+    # Strict mode — fails on any issue (exit code 1):
+    python validate-capture.py <app-dir>
+
+    # Read-only site (skip WRITE-op check):
+    python validate-capture.py <app-dir> --read-only
+
+    # Custom threshold:
+    python validate-capture.py <app-dir> --min-entries 30
+
+    # JSON report for agent consumption:
+    python validate-capture.py <app-dir> --json
+
+Exit codes:
+    0 = all checks passed (or only warnings)
+    1 = at least one blocking failure
+    2 = traffic files missing / malformed
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Check:
+    name: str
+    status: str  # "pass" | "warn" | "fail"
+    detail: str = ""
+
+
+@dataclass
+class Report:
+    app_dir: str
+    checks: list[Check] = field(default_factory=list)
+
+    def add(self, name: str, status: str, detail: str = "") -> None:
+        self.checks.append(Check(name=name, status=status, detail=detail))
+
+    @property
+    def failed(self) -> list[Check]:
+        return [c for c in self.checks if c.status == "fail"]
+
+    @property
+    def warned(self) -> list[Check]:
+        return [c for c in self.checks if c.status == "warn"]
+
+    def to_dict(self) -> dict:
+        return {
+            "app_dir": self.app_dir,
+            "overall": "fail" if self.failed else ("warn" if self.warned else "pass"),
+            "checks": [{"name": c.name, "status": c.status, "detail": c.detail} for c in self.checks],
+        }
+
+
+# --- Individual checks -----------------------------------------------------
+
+def check_entry_count(entries: list[dict], min_entries: int, report: Report) -> None:
+    count = len(entries)
+    if count == 0:
+        report.add("entry_count", "fail", "raw-traffic.json is empty")
+    elif count < min_entries:
+        report.add(
+            "entry_count", "fail",
+            f"only {count} entries (< {min_entries}); browsing was too shallow",
+        )
+    else:
+        report.add("entry_count", "pass", f"{count} entries captured")
+
+
+def check_protocol_identified(analysis: dict, report: Report) -> None:
+    protocol = (analysis.get("protocol") or {}).get("protocol", "unknown")
+    confidence = (analysis.get("protocol") or {}).get("confidence", 0)
+    if protocol == "unknown":
+        report.add("protocol", "fail", "protocol=unknown; analyzer could not classify traffic")
+    elif confidence < 50:
+        report.add("protocol", "warn", f"protocol={protocol} but low confidence ({confidence}%)")
+    else:
+        report.add("protocol", "pass", f"protocol={protocol} (confidence={confidence}%)")
+
+
+def check_write_operations(entries: list[dict], read_only: bool, report: Report) -> None:
+    if read_only:
+        report.add("write_ops", "pass", "read-only site (skipped)")
+        return
+
+    write_methods = {"POST", "PUT", "PATCH", "DELETE"}
+    writes = [
+        e for e in entries
+        if (e.get("method") or "").upper() in write_methods
+    ]
+    if not writes:
+        report.add(
+            "write_ops", "fail",
+            "no POST/PUT/PATCH/DELETE captured; either browse and submit a form, "
+            "or pass --read-only if this is intentional",
+        )
+    else:
+        methods = sorted({(e.get("method") or "").upper() for e in writes})
+        report.add("write_ops", "pass", f"{len(writes)} write ops ({', '.join(methods)})")
+
+
+def check_body_fidelity(entries: list[dict], report: Report) -> None:
+    """Warn if too many API responses have no body (likely truncation)."""
+    api_like = [
+        e for e in entries
+        if (e.get("status") or 0) < 400
+        and (e.get("method") or "").upper() in ("GET", "POST", "PUT", "PATCH")
+        and _looks_like_api(e)
+    ]
+    if not api_like:
+        report.add("body_fidelity", "warn", "no API-like responses to sample")
+        return
+
+    with_body = [e for e in api_like if e.get("response_body") not in (None, "", "[binary content]")]
+    ratio = len(with_body) / len(api_like)
+    if ratio < 0.3:
+        report.add(
+            "body_fidelity", "warn",
+            f"only {int(ratio * 100)}% of API responses have bodies; possible truncation "
+            f"(consider --mitmproxy mode for large payloads)",
+        )
+    else:
+        report.add("body_fidelity", "pass", f"{int(ratio * 100)}% of API responses have bodies")
+
+
+def _looks_like_api(entry: dict) -> bool:
+    mime = (entry.get("mime_type") or "").lower()
+    return (
+        "json" in mime
+        or "xml" in mime
+        or "graphql" in (entry.get("url") or "").lower()
+    )
+
+
+def check_error_rate(entries: list[dict], report: Report) -> None:
+    """Fail if captured traffic is dominated by errors — usually means auth failure."""
+    if not entries:
+        return
+    errors = [e for e in entries if (e.get("status") or 0) >= 400]
+    ratio = len(errors) / len(entries)
+    if ratio > 0.5:
+        report.add(
+            "error_rate", "fail",
+            f"{int(ratio * 100)}% of responses are 4xx/5xx; capture likely had auth or "
+            f"rate-limit failure",
+        )
+    elif ratio > 0.25:
+        report.add("error_rate", "warn", f"{int(ratio * 100)}% error rate (elevated)")
+    else:
+        report.add("error_rate", "pass", f"{int(ratio * 100)}% error rate")
+
+
+def check_endpoint_diversity(entries: list[dict], report: Report) -> None:
+    """Sparse capture: only 1-2 distinct paths = browsing didn't exercise enough."""
+    paths = set()
+    for e in entries:
+        url = e.get("url") or ""
+        if not url:
+            continue
+        path = url.split("?")[0].split("#")[0]
+        paths.add(path)
+    if len(paths) < 3:
+        report.add(
+            "endpoint_diversity", "fail",
+            f"only {len(paths)} distinct URL paths; explore more of the app UI",
+        )
+    elif len(paths) < 8:
+        report.add("endpoint_diversity", "warn", f"only {len(paths)} distinct paths (thin)")
+    else:
+        report.add("endpoint_diversity", "pass", f"{len(paths)} distinct paths")
+
+
+# --- Entry point -----------------------------------------------------------
+
+def load_capture(app_dir: Path) -> tuple[list[dict], dict]:
+    """Return (entries, analysis). Raises FileNotFoundError if files missing."""
+    raw = app_dir / "traffic-capture" / "raw-traffic.json"
+    analysis = app_dir / "traffic-capture" / "traffic-analysis.json"
+    if not raw.exists():
+        raise FileNotFoundError(f"raw-traffic.json not found at {raw}")
+    entries = json.loads(raw.read_text(encoding="utf-8"))
+    analysis_data = json.loads(analysis.read_text(encoding="utf-8")) if analysis.exists() else {}
+    return entries, analysis_data
+
+
+def validate(app_dir: Path, read_only: bool, min_entries: int) -> Report:
+    entries, analysis = load_capture(app_dir)
+    report = Report(app_dir=str(app_dir))
+
+    check_entry_count(entries, min_entries, report)
+    check_endpoint_diversity(entries, report)
+    check_protocol_identified(analysis, report)
+    check_write_operations(entries, read_only, report)
+    check_body_fidelity(entries, report)
+    check_error_rate(entries, report)
+
+    return report
+
+
+def print_human(report: Report) -> None:
+    total = len(report.checks)
+    passed = sum(1 for c in report.checks if c.status == "pass")
+    for c in report.checks:
+        marker = {"pass": "[PASS]", "warn": "[WARN]", "fail": "[FAIL]"}[c.status]
+        line = f"{marker} {c.name}"
+        if c.detail:
+            line += f"  —  {c.detail}"
+        print(line)
+    print()
+    print(f"{passed}/{total} checks passed", end="")
+    if report.warned:
+        print(f", {len(report.warned)} warning(s)", end="")
+    if report.failed:
+        print(f", {len(report.failed)} failure(s)", end="")
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate a Phase-1 capture before handing off to methodology."
+    )
+    parser.add_argument("app_dir", type=Path, help="App directory (e.g., hackernews)")
+    parser.add_argument(
+        "--read-only",
+        action="store_true",
+        help="Skip the WRITE-op requirement (for genuinely read-only sites)",
+    )
+    parser.add_argument(
+        "--min-entries",
+        type=int,
+        default=15,
+        help="Minimum entries required (default: 15)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON report")
+    args = parser.parse_args()
+
+    try:
+        report = validate(args.app_dir, args.read_only, args.min_entries)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(2)
+    except json.JSONDecodeError as exc:
+        print(f"error: malformed traffic JSON: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2, ensure_ascii=False))
+    else:
+        print_human(report)
+
+    sys.exit(1 if report.failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/cli-anything-web-plugin/skills/capture/SKILL.md
+++ b/cli-anything-web-plugin/skills/capture/SKILL.md
@@ -8,7 +8,7 @@ description: >
   "analyze traffic from URL", "assess site", "site fingerprint", "start capture for",
   "open browser for", or any URL is given as the first step of CLI generation.
   DO NOT trigger for: Phase 2 implementation, test writing, or quality validation.
-version: 0.3.0
+version: 0.4.0
 ---
 
 # Traffic Capture (Phase 1)
@@ -43,16 +43,32 @@ Do NOT start unless:
 
 **Default capture method:** playwright-cli tracing (standard workflow below).
 
-**Optional `--mitmproxy` mode:** If the user passed `--mitmproxy` flag to `/cli-anything-web`, use `mitmproxy-capture.py` instead — it provides no body truncation, real-time noise filtering, deduplication, and enhanced metadata (timestamps, cookies, body sizes). Requires `pip install mitmproxy` (Python 3.12+):
-```
+### Optional `--mitmproxy` mode
+
+Use this when the default `--mitmproxy` flag was passed to `/cli-anything-web`,
+or when you need no body truncation, real-time noise filtering, and enhanced
+metadata (timestamps, cookies, body sizes). Requires `pip install mitmproxy`
+(Python 3.12+).
+
+```bash
+# Start the proxy (generates .playwright/cli.proxy.config.json automatically)
 python ${CLAUDE_PLUGIN_ROOT}/scripts/mitmproxy-capture.py start-proxy --port 8080
-npx @playwright/cli@latest open <url> --config=.playwright/cli.proxy.config.json --headed
-# ... browse the site as normal (snapshot, click, fill, goto) ...
+
+# Open the browser routed through the proxy
+npx @playwright/cli@latest -s=<app> open <url> \
+  --config=.playwright/cli.proxy.config.json --headed
+
+# ... browse normally (snapshot, click, fill, goto) ...
+
 npx @playwright/cli@latest -s=<app> close
-python ${CLAUDE_PLUGIN_ROOT}/scripts/mitmproxy-capture.py stop-proxy --port 8080 -o <app>/traffic-capture/raw-traffic.json
+python ${CLAUDE_PLUGIN_ROOT}/scripts/mitmproxy-capture.py stop-proxy \
+  --port 8080 -o <app>/traffic-capture/raw-traffic.json
 ```
 
-If playwright-cli fails, fall back to chrome-devtools-mcp (see HARNESS.md Tool Hierarchy).
+The `start-proxy` command creates `.playwright/cli.proxy.config.json` as part
+of startup — no manual config file needed. When the default playwright-cli path
+fails entirely (e.g., Node not available), fall back to chrome-devtools-mcp via
+`launch-chrome-debug.sh` — see HARNESS.md Tool Hierarchy.
 
 ### Public API Shortcut
 
@@ -130,51 +146,29 @@ npx @playwright/cli@latest -s=<app> run-code "$(grep -v '^\s*//' ${CLAUDE_PLUGIN
 > **IMPORTANT:** The `site-fingerprint.js` script must be loaded via the command
 > above. Do NOT copy-paste the JS inline — it will fail with SyntaxError.
 > The `grep -v` strips comments and `tr` joins lines for single-line execution.
-```
 
 ### Interpret fingerprint results
 
-**Framework:**
-- `googleBatch: true` → Google batchexecute RPC protocol. Generate `rpc/` subpackage.
-- `nextPages: true` → Next.js Pages Router. Extract `__NEXT_DATA__` + trace `/_next/data/` fetches.
-- `nextApp: true` → Next.js App Router. Trace client navigations for RSC payloads.
-- `nuxt: true` → Nuxt. Extract `__NUXT__` + trace API calls.
-- No framework flags → likely SSR HTML or custom SPA. Check for REST API in probe.
+The fingerprint returns four groups: `framework`, `protection`, `auth`, `iframes`.
+Map each `true` flag to the next action:
 
-**Protection:**
-- `cloudflare: true` → Use `curl_cffi` with `impersonate='chrome'` in generated CLI.
-- `awsWaf: true` → Need WAF token cookie via browser. Use curl_cffi for API calls.
-- `captcha: true` → Add pause-and-prompt to auth flow.
-- `serviceWorker: true` → Site has an active Service Worker that may intercept requests
-  and hide them from traces. Note in assessment.md. Generated CLI's auth.py should use
-  `service_workers="block"` in browser context. See `references/protection-detection.md`.
+| Group | Action |
+|---|---|
+| **framework** | See `references/framework-detection.md` for the full protocol table (`googleBatch` / `nextPages` / `nextApp` / `nuxt` / `spaRoot`). |
+| **protection** | See `references/protection-detection.md` — **always start at the escalation ladder at the top** (plain httpx → curl_cffi → curl_cffi + cookies → camoufox → hybrid). |
+| **auth** | Table below (Auth detection section). |
+| **iframes** | If `iframeCount > 0`, see `references/playwright-cli-advanced.md` for the in-iframe re-run snippet. |
 
-**Iframes:**
-- `iframeCount > 0` → App is iframe-embedded. **Re-run detection inside the iframe:**
+Claude-facing shortcuts:
+- `googleBatch: true` → generate `rpc/` subpackage (batchexecute protocol).
+- `cloudflareManagedChallenge: true` → tier 4 (camoufox) is required; `curl_cffi` alone will fail.
+- `awsWaf: true` → capture `aws-waf-token` cookie; use `curl_cffi` for GraphQL, cookie-only for SSR.
+- `akamai: true` or `datadome: true` → 1–2 s delays between requests are mandatory.
+- `serviceWorker: true` → note in assessment.md; generated CLI uses `service_workers="block"`.
+- `iframeCount > 0` → re-run the fingerprint inside the iframe. Google Labs apps (Stitch / MusicFX / ImageFX) follow this pattern — parent has `WIZ_global_data`, iframe has the real app.
 
-```bash
-npx @playwright/cli@latest -s=<app> run-code "async page => {
-  const frame = page.frames()[1];
-  if (!frame) return { error: 'no iframe found' };
-  return await frame.evaluate(() => ({
-    framework: {
-      nextPages: !!document.getElementById('__NEXT_DATA__'),
-      googleBatch: typeof WIZ_global_data !== 'undefined',
-      spaRoot: document.querySelector('#app, #root')?.id || null,
-      vite: !!document.querySelector('script[type=\"module\"][src*=\"/@vite\"]') || !!document.querySelector('script[type=\"module\"][src*=\"/src/\"]')
-    },
-    title: document.title,
-    bodyPreview: document.body?.textContent?.substring(0, 300) || ''
-  }));
-}"
-```
-
-Common iframe pattern: Google Labs apps (Stitch, MusicFX, ImageFX) embed a
-Vite/React SPA in an iframe. Parent has `WIZ_global_data`, iframe has the real app.
-See `references/playwright-cli-advanced.md` for iframe interaction patterns.
-
-**Note:** `snapshot` and `click <ref>` auto-resolve iframes. Only use `run-code`
-for iframe interaction when built-in commands fail.
+**Note:** `snapshot` and `click <ref>` auto-resolve iframes. Only drop down to
+`run-code` for iframe interaction when built-in commands fail.
 
 ### Auth detection (BEFORE exploration)
 
@@ -189,9 +183,10 @@ Check the fingerprint auth fields:
 **If auth is needed:**
 1. Tell the user: "This site requires login. Please log in in the browser window."
 2. Wait for user confirmation
-3. Save auth state:
+3. Save auth state and tighten permissions (CLAUDE.md mandates `chmod 600`):
 ```bash
 npx @playwright/cli@latest -s=<app> state-save <app>/traffic-capture/<app>-auth.json
+chmod 600 <app>/traffic-capture/<app>-auth.json
 ```
 
 **If NO auth is needed:** Skip directly to Step 2b.
@@ -220,9 +215,16 @@ npx @playwright/cli@latest -s=<app> click <internal-link-2>
 npx @playwright/cli@latest -s=<app> click <internal-link-3>
 npx @playwright/cli@latest -s=<app> tracing-stop
 
-# Quick parse to see what endpoints appeared
-python ${CLAUDE_PLUGIN_ROOT}/scripts/parse-trace.py .playwright-cli/traces/ --latest --output /tmp/probe.json
+# Quick parse to see what endpoints appeared (saved alongside the full capture
+# so it survives the session — don't output to /tmp).
+python ${CLAUDE_PLUGIN_ROOT}/scripts/parse-trace.py .playwright-cli/traces/ --latest \
+  --output <app>/traffic-capture/probe-traffic.json
 ```
+
+This probe trace is separate from the full capture in Step 3 — Step 3 will
+start a fresh trace that overwrites the `.network` file in `.playwright-cli/traces/`.
+The parsed `probe-traffic.json` is kept in `traffic-capture/` so it stays available
+for cross-referencing during Step 4.
 
 Check the probe results — what API patterns did you find?
 See `references/api-discovery.md` for the priority chain and decision tree.
@@ -281,53 +283,21 @@ npx @playwright/cli@latest -s=<app> tracing-start
 
 ### Exploration by site profile
 
-Use the profile-specific checklist from Step 2b:
+Use the **concrete targets** in `references/exploration-checklists.md` for the
+profile identified in Step 2b. Each profile has an explicit entry count,
+distinct-path count, and WRITE-op target that `validate-capture.py` (Step 4)
+will enforce. Minimum bar across all profiles:
 
-**Auth + CRUD:**
-```
-For EACH resource visible in the UI:
-- [ ] List/browse: navigate to list view
-- [ ] Detail: open one item
-- [ ] Create: fill form, submit (capture POST body!)
-- [ ] Update: edit an item, save
-- [ ] Delete: delete a test item
-- [ ] Settings/profile: check app settings
-- [ ] Export: if available, trigger export/download
-```
+- ≥ 15 entries, ≥ 3 distinct URL paths, protocol ≠ `unknown`
+- ≥ 1 WRITE op (unless the site is genuinely read-only — pass `--read-only` to the validator)
+- < 50% error rate (dominant 4xx/5xx means auth or rate-limit failure)
 
-**Auth + Generation:**
-```
-- [ ] Dashboard/projects: navigate to project list
-- [ ] Open existing project: view editor/canvas
-- [ ] Generate new content: type prompt, click generate, WAIT for completion
-- [ ] Edit/iterate: modify generation, re-generate
-- [ ] Export/download: trigger download of generated content
-- [ ] Delete: delete a test project
-- [ ] Settings: check model selection, preferences
-```
+### Pacing for protected sites
 
-**Auth + Read-only:**
-```
-- [ ] Main view: navigate to primary content
-- [ ] Search/filter: use search functionality
-- [ ] Detail pages: open 2-3 different items
-- [ ] Pagination: go to page 2 if available
-- [ ] Export: if available
-```
-
-**No-auth + CRUD:**
-```
-Same as Auth + CRUD, but skip auth-related captures.
-```
-
-**No-auth + Read-only:**
-```
-- [ ] Homepage: capture initial data
-- [ ] Search: try 2-3 different queries
-- [ ] Detail pages: open 2-3 items
-- [ ] Filters: apply different filters
-- [ ] Pagination: check next page
-```
+If any of `cloudflare`, `cloudflareManagedChallenge`, `akamai`, `datadome`,
+`awsWaf`, or `rateLimit` fired in the fingerprint, **leave 1–2 s between
+clicks / form submits**. Faster exploration triggers per-IP challenges within
+~30 requests and corrupts the trace.
 
 ### General interaction rules
 
@@ -335,18 +305,16 @@ Same as Auth + CRUD, but skip auth-related captures.
 - **Refs go stale** — always take a fresh snapshot before clicking
 - **For localized UIs** (Hebrew, Arabic, etc.) — use refs or data-testid, not text
 - **For iframe-embedded apps** — `snapshot` + `click <ref>` auto-resolves iframes
-- **Wait after generation** — if the app generates content async, wait:
+- **Wait after generation** — if the app generates content async, wait for ≥ 15 s
+  before the next action, otherwise the polling loop won't appear in the trace:
   ```bash
   npx @playwright/cli@latest -s=<app> run-code "async page => {
     await page.waitForTimeout(15000);
     return 'waited';
   }"
   ```
-- **The trace MUST contain at least one WRITE operation** (POST/PUT/DELETE) unless
-  the site is genuinely read-only (see exception below)
-
-**Exception for read-only sites:** If the site is genuinely read-only, the trace
-may contain only GET requests. Note "read-only site" in `assessment.md` and proceed.
+- **Debounced inputs** — after typing a search query, pause 1–2 s before the
+  next action; submitting immediately misses the auto-complete endpoint.
 
 ---
 
@@ -369,23 +337,36 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/parse-trace.py \
 # parse-trace.py now auto-runs analyze-traffic.py and produces:
 #   - <app>/traffic-capture/raw-traffic.json (raw request/response data)
 #   - <app>/traffic-capture/traffic-analysis.json (auto-detected protocol, auth, endpoints)
-#
-# The analysis output shows: protocol type, auth pattern, endpoint groups,
-# GraphQL operations, batchexecute RPC IDs, and suggested CLI commands.
-# Review the analysis — anything marked "unknown" needs manual investigation.
 
-# You can also run the analyzer separately for more detail:
+# Gate — validate the capture before declaring Phase 1 complete.
+# This check enforces: ≥15 entries, ≥3 distinct paths, protocol ≠ unknown,
+# ≥1 WRITE op (add --read-only if the site is genuinely read-only), <50% error rate.
+python ${CLAUDE_PLUGIN_ROOT}/scripts/validate-capture.py <app>
+# OR for genuinely read-only sites:
+# python ${CLAUDE_PLUGIN_ROOT}/scripts/validate-capture.py <app> --read-only
+```
+
+If `validate-capture.py` returns a non-zero exit code, **do not proceed to Step 5**.
+Re-open the browser (Step 1), continue exploration to fill the gaps the validator
+flagged, then re-run Step 4. Only mark the capture complete after the validator
+passes (or warns, with your explicit sign-off on each warning).
+
+For deeper inspection:
+
+```bash
 python ${CLAUDE_PLUGIN_ROOT}/scripts/analyze-traffic.py \
   <app>/traffic-capture/raw-traffic.json --summary
 ```
 
-> **If `--mitmproxy` mode:** Replace everything above with:
+> **If `--mitmproxy` mode:** Replace the parse/analyze block above with:
 > ```bash
 > # Stop the proxy and save captured traffic (includes auto-analysis)
 > python ${CLAUDE_PLUGIN_ROOT}/scripts/mitmproxy-capture.py stop-proxy \
 >   --port 8080 -o <app>/traffic-capture/raw-traffic.json
 >
-> # The stop-proxy command writes raw-traffic.json directly.
+> # Validate the capture (same gate applies)
+> python ${CLAUDE_PLUGIN_ROOT}/scripts/validate-capture.py <app>
+>
 > # Then run the analyzer for the full report:
 > python ${CLAUDE_PLUGIN_ROOT}/scripts/analyze-traffic.py \
 >   <app>/traffic-capture/raw-traffic.json --summary
@@ -430,7 +411,12 @@ and build the CLI.
 
 ## References
 
-See `references/` for: command syntax (playwright-cli-commands.md), tracing (playwright-cli-tracing.md),
-sessions (playwright-cli-sessions.md), advanced patterns (playwright-cli-advanced.md),
-framework detection (framework-detection.md), protection (protection-detection.md),
-API discovery (api-discovery.md).
+See `references/` for:
+- `playwright-cli-commands.md` — command syntax, timeouts, ESM rules
+- `playwright-cli-tracing.md` — trace file format, recovery protocol
+- `playwright-cli-sessions.md` — named sessions, auth persistence
+- `playwright-cli-advanced.md` — waits, iframes, localized UIs, downloads
+- `framework-detection.md` — framework → protocol table
+- `protection-detection.md` — anti-bot escalation ladder (curl_cffi → camoufox → hybrid)
+- `api-discovery.md` — protocol priority chain, decision tree
+- `exploration-checklists.md` — per-profile capture targets with concrete numbers

--- a/cli-anything-web-plugin/skills/capture/references/exploration-checklists.md
+++ b/cli-anything-web-plugin/skills/capture/references/exploration-checklists.md
@@ -1,0 +1,122 @@
+# Exploration Checklists
+
+Concrete targets for each site profile. Used during Step 3 (full capture) to
+exercise enough of the API surface that `validate-capture.py` passes.
+
+> **Pacing:** leave **1–2 seconds** between clicks/form submits on any site
+> flagged with `cloudflare`, `akamai`, `datadome`, `awsWaf`, or `rateLimit`.
+> Faster exploration triggers per-IP challenges within ~30 requests.
+
+> **Minimum bar (enforced by validate-capture.py):**
+> `≥ 15 entries`, `≥ 3 distinct URL paths`, protocol ≠ `unknown`, `≥ 1 WRITE op`
+> (unless `--read-only`), `< 50%` error rate.
+
+---
+
+## Auth + CRUD
+
+**Target:** ≥ 25 requests, ≥ 3 WRITE ops, ≥ 3 distinct resources touched.
+
+For EACH resource (post / file / item / etc.) visible in the UI:
+
+- [ ] **List** — navigate to the list view
+- [ ] **Read detail** — open one item; load detail page
+- [ ] **Paginate** — scroll or click page 2 (exercises cursor / page param)
+- [ ] **Create** — fill the form, submit (capture the POST body!)
+- [ ] **Update** — edit an existing item, save (PUT/PATCH)
+- [ ] **Delete** — remove a test item (DELETE)
+
+Plus once per app:
+
+- [ ] **Search** — run ≥ 2 distinct search queries (surfaces search endpoint)
+- [ ] **Settings / profile** — open settings page (user-info endpoints)
+- [ ] **Export or download** if the feature exists
+
+---
+
+## Auth + Generation
+
+**Target:** ≥ 20 requests, ≥ 2 WRITE ops, at least one complete generation cycle.
+
+- [ ] **Project list** — navigate to the dashboard / project list
+- [ ] **Open existing project** — view the editor / canvas
+- [ ] **Generate new content** — enter prompt, click generate, **WAIT for completion** (async!)
+- [ ] **Poll** — let the client poll for status; capture ≥ 3 poll cycles
+- [ ] **Iterate** — modify parameters, re-generate (exercises re-run endpoint)
+- [ ] **Export / download** — save the generated artifact
+- [ ] **Delete** — remove a test project
+- [ ] **Settings** — check model selection / preferences
+
+**Async gotcha:** after clicking generate, wait at least 15 s before the next
+action or the polling loop won't appear in the trace.
+
+---
+
+## Auth + Read-only
+
+**Target:** ≥ 15 requests, all GET; ≥ 2 search queries; ≥ 3 detail pages.
+
+- [ ] **Main feed** — navigate to primary content (dashboard / home)
+- [ ] **Search** — run ≥ 2 different queries (exercises query/filter endpoint)
+- [ ] **Detail pages** — open ≥ 3 different items
+- [ ] **Pagination** — scroll or click page 2
+- [ ] **Filters** — apply ≥ 1 non-default filter
+- [ ] **Export** — if available
+
+Run with `validate-capture.py --read-only` — the WRITE-op check is skipped.
+
+---
+
+## No-auth + CRUD
+
+Same targets as **Auth + CRUD** above; just skip auth-saving steps.
+Some sites (e.g., Dev.to) accept optional API-key auth — if so, capture once
+without auth and once with auth to see how responses differ.
+
+---
+
+## No-auth + Read-only
+
+**Target:** ≥ 15 GET requests, ≥ 3 distinct URL paths.
+
+- [ ] **Homepage / landing** — capture initial data + hydration calls
+- [ ] **Search** — try ≥ 2 queries (separate terms, not just "a", "b")
+- [ ] **Detail pages** — open ≥ 3 items from different categories
+- [ ] **Filters** — apply ≥ 2 filters (date range, category, sort)
+- [ ] **Pagination** — go to page 2 or scroll until a new XHR fires
+
+Run with `validate-capture.py --read-only`.
+
+---
+
+## Coverage heuristics — "have I browsed enough?"
+
+General rules of thumb regardless of profile:
+
+1. **One screen = one endpoint group minimum.** If you haven't opened a screen,
+   its endpoints aren't in the trace. Open every top-level nav item.
+2. **Modals fire their own endpoints.** If the app opens a modal on click,
+   trigger at least one modal — its data loads lazily.
+3. **Infinite-scroll triggers new requests at scroll breakpoints.** Scroll
+   until you see a new XHR in DevTools (usually 2–3 viewport heights).
+4. **Debounced inputs fire only after typing stops.** When testing search,
+   type the query and then **wait 1–2 s**. Submitting without the pause
+   misses the auto-complete endpoint entirely.
+5. **Context-scoped apps need the context switch captured.** Apps like
+   NotebookLM / Stitch scope all calls to the active notebook/project —
+   switching notebook fires the "load workspace" endpoints you'll need.
+
+---
+
+## When a checklist step can't be completed
+
+Record the reason in `assessment.md` and continue. Examples:
+
+- **"Create" blocked by paywall** → note it; capture what you can.
+- **CAPTCHA on login** → switch to pause-and-prompt flow; mark auth flow as
+  `requires_manual_captcha` in assessment.md.
+- **Geo-blocked feature** → note the country where capture was run; some
+  endpoints may be unreachable.
+
+Do NOT let a blocked step stop the whole capture — move on and let
+`validate-capture.py` flag residual gaps.

--- a/cli-anything-web-plugin/skills/capture/references/protection-detection.md
+++ b/cli-anything-web-plugin/skills/capture/references/protection-detection.md
@@ -55,17 +55,29 @@ Interpret the result object — any `true` value means that protection is presen
 
 ---
 
+## Anti-Bot Escalation Ladder
+
+When the fingerprint flags any protection, climb the ladder from simplest to
+heaviest. Stop at the first tier that reaches HTTP 200 on a real endpoint.
+
+| Tier | Tool | Works for | Proof in this repo |
+|---|---|---|---|
+| 1 | plain `httpx` | unprotected / permissive sites | hackernews, youtube, gh-trending |
+| 2 | `curl_cffi` with `impersonate='chrome'` | Cloudflare basic, most WAFs | reddit, pexels, producthunt, unsplash |
+| 3 | `curl_cffi` + browser-captured token cookie | AWS WAF, Akamai / DataDome | booking (aws-waf-token), airbnb (curl_cffi + delays) |
+| 4 | `camoufox` (stealth Firefox, headless) | Cloudflare **managed challenge** | chatgpt |
+| 5 | Hybrid (`camoufox` for auth + `curl_cffi` for read) | sites that challenge auth but allow read | chatgpt (auth via camoufox, chat via curl_cffi) |
+
+Ladder rule: **never skip a tier**. Start with tier 2 when any protection is
+flagged; escalate only if the tier below returns 401/403 or a challenge page.
+
+---
+
 ## Cloudflare
 
-### Impact on CLI Generation
+### Basic Cloudflare (passes on TLS fingerprint alone)
 
-Cloudflare blocks standard HTTP clients (`httpx`, `requests`) because their TLS
-fingerprints don't match real browsers. Two strategies:
-
-**Strategy 1: `curl_cffi` with TLS impersonation (preferred)**
-
-Use `curl_cffi` instead of `httpx` — it impersonates Chrome's TLS fingerprint,
-which passes Cloudflare without any cookies or browser session:
+`curl_cffi` with `impersonate='chrome'` is almost always sufficient:
 
 ```python
 from curl_cffi import requests as curl_requests
@@ -78,25 +90,116 @@ Add `curl_cffi` and `beautifulsoup4` to `setup.py` dependencies (instead of `htt
 This approach requires NO auth, NO cookies, NO browser session. It works because
 Cloudflare primarily checks the TLS fingerprint, not the cookie jar.
 
-**Strategy 2: Browser cookies (fallback)**
+### Cloudflare Managed Challenge ("Just a moment…")
 
-If `curl_cffi` doesn't work (some sites check more than TLS), fall back to:
-- Use playwright `state-save` to capture `cf_clearance` + `__cf_bm` cookies
-- Pass cookies to `httpx` requests
-- Cookies expire — users must re-run `auth login` periodically
+Fingerprint flag: `protection.cloudflareManagedChallenge: true`.
 
-**Strategy 1 is strongly preferred** — it's simpler, needs no auth, and doesn't expire.
+When Cloudflare serves the interstitial page, `curl_cffi` alone fails (returns
+the challenge HTML instead of the real page). Use **camoufox** — a stealth
+Firefox build that passes the managed challenge headless:
+
+```bash
+pip install camoufox
+python -m camoufox fetch  # downloads the stealth Firefox binary
+```
+
+Hybrid pattern (mirrors chatgpt CLI):
+
+```python
+from camoufox.sync_api import Camoufox
+from curl_cffi import requests as curl_requests
+
+# 1. Use camoufox only for auth / challenge-gated pages
+with Camoufox(headless=True, humanize=True) as browser:
+    page = browser.new_page()
+    page.goto("https://chatgpt.com/login")
+    # ... log in, then harvest cookies ...
+    cookies = {c["name"]: c["value"] for c in page.context.cookies()}
+
+# 2. Use curl_cffi for the rest — much faster
+resp = curl_requests.get("https://chatgpt.com/backend-api/conversations",
+                         cookies=cookies, impersonate="chrome")
+```
+
+**Detection heuristic at runtime:** if a response contains `"Just a moment..."` in
+the `<title>` or `cf-chl-bypass` in the body, escalate to tier 4 for that endpoint.
+
+### Fallback: browser cookies
+
+If `curl_cffi` gets 403 but the body doesn't contain a managed-challenge marker,
+try tier 3: capture `cf_clearance` + `__cf_bm` via `state-save` and pass to
+`curl_cffi` alongside `impersonate='chrome'`. Cookies expire — users re-run
+`auth login` periodically.
 
 **Protection can appear after launch.** Sites add anti-bot protection over time.
-Unsplash added it in March 2026 — a CLI that worked fine with `httpx` suddenly started
-getting 401 "Making sure you're not a bot!" responses. When this happens, switch from
-`httpx` to `curl_cffi` with `impersonate="chrome131"`. Detection: HTTP 401/403 response
-body contains "not a bot", "challenge", or "Cloudflare" text.
+Unsplash added it in March 2026 — a CLI that worked fine with `httpx` suddenly
+started getting 401 "Making sure you're not a bot!" responses. When this happens,
+switch from `httpx` to `curl_cffi` with `impersonate="chrome131"`. Detection:
+HTTP 401/403 response body contains "not a bot", "challenge", or "Cloudflare".
 
 ### General Cloudflare rules:
 - Add realistic delays between requests (1-3 seconds)
 - Respect rate limits strictly — Cloudflare escalates protections on abuse
 - Never retry failed requests rapidly — exponential backoff only
+
+---
+
+## AWS WAF (Booking.com pattern)
+
+Fingerprint flag: `protection.awsWaf: true`.
+
+AWS WAF returns a 202 JavaScript-challenge page to raw HTTP clients. The bypass
+pattern used by the booking CLI:
+
+1. **GraphQL endpoints** — `curl_cffi` with `impersonate='chrome'` passes the
+   WAF cold, no cookies needed. Use this tier first for any JSON API.
+2. **SSR HTML pages** — require an `aws-waf-token` cookie obtained via a browser
+   session. After `state-save`, pass ONLY the `aws-waf-token` cookie:
+
+   ```python
+   # Critical: use ONLY aws-waf-token on SSR requests.
+   # The bkng session cookie contains affiliate data that triggers
+   # server-side redirects on detail pages.
+   cookies = {"aws-waf-token": saved["aws-waf-token"]}
+   resp = curl_requests.get(url, cookies=cookies, impersonate="chrome")
+   ```
+
+3. **Hotel detail pages** redirect when date/occupancy params are present —
+   fetch without them, then parse the response for availability data.
+
+---
+
+## Akamai Bot Manager / DataDome (Airbnb pattern)
+
+Fingerprint flags: `protection.akamai: true` / `protection.datadome: true`.
+
+Akamai's Bot Manager and DataDome inspect JA3/JA4 TLS fingerprints plus header
+ordering. `curl_cffi` with `impersonate='chrome'` handles both in most cases.
+Additional rules observed on the airbnb CLI (~780 requests in capture):
+
+- **Minimum 1-2s delay between requests** — back-to-back requests trigger
+  per-IP challenges within ~30 requests.
+- **Impersonate the latest Chrome** (`impersonate='chrome131'`) — older
+  fingerprints (`chrome110`) get flagged.
+- **Preserve the `_abck` / `bm_sz` / `bm_sv` cookies** from browser capture
+  (Akamai) and `datadome` cookie (DataDome). Pass them on every request.
+- **Rotate the User-Agent** only if you've already rotated the TLS fingerprint
+  to match; mismatched UA+TLS is the strongest bot signal.
+
+If both `curl_cffi` tiers fail, the site is tier-4/5 camoufox territory.
+
+---
+
+## PerimeterX
+
+Fingerprint flag: `protection.perimeterx: true`.
+
+PerimeterX (now HUMAN) often renders a CAPTCHA the first time. Options:
+
+- **Auth flow:** pause-and-prompt — ask the user to solve the CAPTCHA in the
+  visible browser, then resume capture.
+- **Data pages:** usually also challenged; may not be CLI-suitable without a
+  paid/residential IP rotation.
 
 ---
 
@@ -142,31 +245,19 @@ npx @playwright/cli@latest -s=<app> run-code "async page => { return await page.
 
 ---
 
-## WAF Detection
-
-### Impact on CLI Generation
-
-WAFs significantly increase the difficulty of automated access:
-
-| WAF | Severity | Recommended approach |
-|---|---|---|
-| Akamai Bot Manager | High | Manual browser auth, cookie persistence |
-| Imperva / Incapsula | High | May require residential IP + cookie rotation |
-| PerimeterX | High | Often triggers CAPTCHA — pause-and-prompt flow |
-| DataDome | Medium-High | Fingerprint detection — add delays, rotate sessions |
-
-For any detected WAF, note it prominently in the app's `<APP>.md` Warnings section.
-
----
-
 ## Summary: What Each Finding Means
 
-| Finding | CLI Generation Impact |
-|---|---|
-| Cloudflare detected | Add delays, note possible challenge pages |
-| Rate limits detected | Build backoff into client, default to conservative rates |
-| CAPTCHA on auth | Add pause-and-prompt to login flow |
-| CAPTCHA on data pages | Site may not be CLI-suitable |
-| WAF detected (any) | Flag as protected, may need manual browser session |
-| Fingerprinting scripts | Automated access will be harder — note in warnings |
-| Clean (no protections) | Standard capture and generation, no special handling |
+| Fingerprint flag | Start at ladder tier | Notes |
+|---|---|---|
+| `cloudflare: true` | 2 (curl_cffi) | Most common — TLS impersonation alone suffices |
+| `cloudflareManagedChallenge: true` | 4 (camoufox) | Headless Firefox required for interstitial |
+| `awsWaf: true` | 2 for JSON APIs; 3 for SSR | SSR needs `aws-waf-token` cookie only |
+| `akamai: true` | 3 (curl_cffi + delays + cookies) | 1-2s delays mandatory |
+| `datadome: true` | 3 | Same pattern as Akamai |
+| `perimeterx: true` | Manual CAPTCHA | Pause-and-prompt for auth; data pages often unreachable |
+| `captcha: true` | Manual CAPTCHA | Add pause-and-prompt to auth flow |
+| `rateLimit: true` | 2 | Build backoff into client, respect Retry-After |
+| `serviceWorker: true` | N/A | Restart browser with `service_workers='block'` |
+| All `false` | 1 (plain httpx) | Standard capture and generation |
+
+For any detected protection, note it prominently in the app's `<APP>.md` Warnings section and record which ladder tier ended up working.

--- a/cli-anything-web-plugin/templates/auth_google_sso.py.tpl
+++ b/cli-anything-web-plugin/templates/auth_google_sso.py.tpl
@@ -1,0 +1,342 @@
+"""Auth management for cli-web-${app_name} (Google SSO).
+
+Handles:
+- Login via Python playwright (opens browser, saves state)
+- Cookie import from JSON file (manual fallback)
+- Secure storage at ~/.config/cli-web-${app_name}/auth.json with chmod 600
+- Regional cookie priority (.google.com > .google.co.il / .google.de / etc.) —
+  CRITICAL for international users (see CLAUDE.md "Auth cookie priority")
+
+Customize:
+- BASE_URL — the app's landing URL
+- AUTH_COOKIE_NAMES — which Google cookies matter for this app
+- fetch_tokens() — per-app CSRF / session-id regex extraction
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+from .exceptions import AuthError
+
+# ---------------------------------------------------------------------------
+# Customize these for your app
+# ---------------------------------------------------------------------------
+
+BASE_URL = "https://FILL_IN_BASE_URL"
+GOOGLE_ACCOUNTS_URL = "https://accounts.google.com/"
+
+AUTH_DIR = Path.home() / ".config" / "cli-web-${app_name}"
+AUTH_FILE = AUTH_DIR / "auth.json"
+ENV_VAR = "CLI_WEB_${APP_NAME}_AUTH_JSON"
+BROWSER_PROFILE_DIR = AUTH_DIR / "browser-profile"
+
+# Google SID-family cookies — extend if the target app needs additional ones.
+AUTH_COOKIE_NAMES = {
+    "SID", "HSID", "SSID", "APISID", "SAPISID",
+    "__Secure-1PSID", "__Secure-3PSID",
+    "__Secure-1PSIDTS", "__Secure-3PSIDTS",
+    "__Secure-1PAPISID", "__Secure-3PAPISID",
+    "NID", "LSID", "OSID",
+}
+
+# Regional Google ccTLDs for international users. Cookies from any of these
+# domains are recognized, but `.google.com` values take priority.
+GOOGLE_REGIONAL_CCTLDS = frozenset({
+    "google.co.uk", "google.co.jp", "google.co.kr", "google.co.in",
+    "google.co.il", "google.co.za", "google.co.nz", "google.co.id",
+    "google.co.th", "google.co.ke", "google.co.tz",
+    "google.com.au", "google.com.br", "google.com.sg", "google.com.hk",
+    "google.com.mx", "google.com.ar", "google.com.tr", "google.com.tw",
+    "google.com.eg", "google.com.pk", "google.com.ng", "google.com.ph",
+    "google.com.co", "google.com.vn", "google.com.ua", "google.com.pe",
+    "google.com.sa", "google.com.my", "google.com.bd",
+    "google.de", "google.fr", "google.it", "google.es", "google.nl",
+    "google.pl", "google.se", "google.no", "google.fi", "google.dk",
+    "google.at", "google.ch", "google.be", "google.pt", "google.ie",
+    "google.cz", "google.ro", "google.hu", "google.gr", "google.bg",
+    "google.sk", "google.hr", "google.lt", "google.lv", "google.ee",
+    "google.si",
+    "google.ru", "google.ca", "google.cl", "google.ae",
+})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _auth_dir_setup() -> None:
+    AUTH_DIR.mkdir(parents=True, exist_ok=True)
+
+
+@contextmanager
+def _windows_playwright_event_loop():
+    """On Windows, Playwright's sync API needs the default event loop policy.
+
+    Non-op on POSIX. Always use this around ``sync_playwright()`` calls.
+    """
+    if sys.platform != "win32":
+        yield
+        return
+    original = asyncio.get_event_loop_policy()
+    asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
+    try:
+        yield
+    finally:
+        asyncio.set_event_loop_policy(original)
+
+
+def _ensure_chromium_installed() -> None:
+    """Check for Chromium and install it once if missing.
+
+    Silently no-ops if the playwright CLI is unavailable — sync_playwright()
+    may still work with a different browser binary.
+    """
+    try:
+        result = subprocess.run(
+            ["playwright", "install", "--dry-run", "chromium"],
+            capture_output=True, text=True,
+        )
+        stdout_lower = result.stdout.lower()
+        if "chromium" not in stdout_lower or "will download" not in stdout_lower:
+            return
+        print("Chromium browser not installed. Installing now...")
+        install_result = subprocess.run(
+            ["playwright", "install", "chromium"],
+            capture_output=True, text=True,
+        )
+        if install_result.returncode != 0:
+            raise AuthError("Failed to install Chromium. Run: playwright install chromium")
+        print("Chromium installed successfully.")
+    except (FileNotFoundError, AuthError):
+        pass
+
+
+def _extract_cookies(raw_cookies: list) -> dict:
+    """Filter + prioritize Google auth cookies.
+
+    Supports .google.com and all regional ccTLDs. Critically, values from
+    `.google.com` win over regional duplicates (e.g. `.google.co.il`) — this
+    is the fix mandated by CLAUDE.md line 93 for international users.
+    """
+    result: dict[str, str] = {}
+    allowed = {
+        ".google.com", "google.com",
+        ".accounts.google.com", "accounts.google.com",
+        ".googleusercontent.com",
+    }
+    for cctld in GOOGLE_REGIONAL_CCTLDS:
+        allowed.add(f".{cctld}")
+        allowed.add(cctld)
+
+    for c in raw_cookies:
+        domain = c.get("domain", "")
+        name = c.get("name", "")
+        if domain not in allowed or not name:
+            continue
+        # Only overwrite an existing entry if the new one is from .google.com
+        # (the authoritative domain).
+        if name not in result or domain == ".google.com":
+            result[name] = c.get("value", "")
+    return result
+
+
+def _save_auth(data: dict) -> None:
+    _auth_dir_setup()
+    AUTH_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    try:
+        os.chmod(AUTH_FILE, 0o600)
+    except OSError:
+        pass  # Windows may not support chmod
+
+
+# ---------------------------------------------------------------------------
+# Login flows
+# ---------------------------------------------------------------------------
+
+def login_browser(headed: bool = True) -> None:
+    """Open Chromium via Python playwright for Google login; save state.
+
+    Uses ``sync_playwright()`` with a persistent context — NOT the npx
+    playwright-cli wrapper (that has interactive-input / Popen race issues).
+    """
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        raise AuthError(
+            "Playwright not installed. Run:\n"
+            "  pip install playwright\n"
+            "  playwright install chromium"
+        )
+
+    _auth_dir_setup()
+    _ensure_chromium_installed()
+    state_file = AUTH_DIR / "playwright-state.json"
+    BROWSER_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+
+    print("Opening Chromium for Google login...")
+
+    with _windows_playwright_event_loop(), sync_playwright() as p:
+        context = p.chromium.launch_persistent_context(
+            user_data_dir=str(BROWSER_PROFILE_DIR),
+            headless=not headed,
+            args=[
+                "--disable-blink-features=AutomationControlled",
+                "--password-store=basic",
+            ],
+            ignore_default_args=["--enable-automation"],
+        )
+        page = context.pages[0] if context.pages else context.new_page()
+        page.goto(BASE_URL)
+
+        print("\nInstructions:")
+        print("1. Complete the Google login in the browser window")
+        print(f"2. Wait until you see the cli-web-${app_name} homepage")
+        print("3. Press ENTER here to save and close\n")
+        input("[Press ENTER when logged in] ")
+
+        # Force .google.com cookies for regional users: navigate to
+        # accounts.google.com and back to our base URL. This writes the
+        # authoritative cookie set even if the user's region redirected
+        # them through a regional domain.
+        try:
+            page.goto(GOOGLE_ACCOUNTS_URL, wait_until="load")
+        except Exception:
+            pass
+        try:
+            page.goto(BASE_URL, wait_until="load")
+        except Exception:
+            pass
+
+        context.storage_state(path=str(state_file))
+        context.close()
+
+    try:
+        state = json.loads(state_file.read_text(encoding="utf-8"))
+        cookies = _extract_cookies(state.get("cookies", []))
+        if not cookies:
+            raise AuthError("No Google cookies found in browser state. Did you log in?")
+        _save_auth({"cookies": cookies})
+        print(f"Auth saved to {AUTH_FILE}")
+    except (json.JSONDecodeError, KeyError) as e:
+        raise AuthError(f"Failed to parse playwright state: {e}")
+
+
+def login_from_cookies_json(filepath: str) -> None:
+    """Import cookies from a JSON file (manual fallback).
+
+    Accepts either playwright ``state-save`` format or a plain cookies array.
+    """
+    _auth_dir_setup()
+    try:
+        data = json.loads(Path(filepath).read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, FileNotFoundError) as e:
+        raise AuthError(f"Cannot read cookies file: {e}")
+
+    if isinstance(data, dict) and "cookies" in data:
+        raw_cookies = data["cookies"]
+    elif isinstance(data, list):
+        raw_cookies = data
+    else:
+        raise AuthError("Unrecognized cookies format — expected array or {cookies: [...]}")
+
+    cookies = _extract_cookies(raw_cookies)
+    if not cookies:
+        raise AuthError("No Google cookies found in file")
+    _save_auth({"cookies": cookies})
+    print(f"Auth saved to {AUTH_FILE} ({len(cookies)} cookies)")
+
+
+def load_cookies() -> dict:
+    """Load stored cookies: env var first, then the auth file.
+
+    Handles both flat ``{name: value}`` dicts and raw playwright
+    ``[{name, value, domain}, ...]`` arrays.
+    """
+    env_auth = os.environ.get(ENV_VAR)
+    if env_auth:
+        try:
+            data = json.loads(env_auth)
+            cookies = data.get("cookies", data) if isinstance(data, dict) else data
+            if isinstance(cookies, list):
+                cookies = _extract_cookies(cookies)
+            if cookies:
+                return cookies
+        except (json.JSONDecodeError, TypeError):
+            pass  # fall through to file
+
+    if not AUTH_FILE.exists():
+        raise AuthError("Not authenticated. Run: cli-web-${app_name} auth login")
+    try:
+        data = json.loads(AUTH_FILE.read_text(encoding="utf-8"))
+        cookies = data.get("cookies", {})
+        if not cookies:
+            raise AuthError("No cookies found. Run: cli-web-${app_name} auth login")
+        if isinstance(cookies, list):
+            cookies = _extract_cookies(cookies)
+            if not cookies:
+                raise AuthError("No Google cookies found. Run: cli-web-${app_name} auth login")
+        return cookies
+    except (json.JSONDecodeError, KeyError) as e:
+        raise AuthError(f"Corrupted auth file: {e}. Run: cli-web-${app_name} auth login")
+
+
+def clear_auth() -> None:
+    """Remove auth file."""
+    if AUTH_FILE.exists():
+        AUTH_FILE.unlink()
+
+
+def is_logged_in() -> bool:
+    try:
+        load_cookies()
+        return True
+    except AuthError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Per-app token extraction — CUSTOMIZE for your app's homepage
+# ---------------------------------------------------------------------------
+
+def fetch_tokens(cookies: dict) -> dict:
+    """Fetch the homepage and extract short-lived auth tokens.
+
+    Google batchexecute apps typically need: ``SNlM0e`` (CSRF / ``at``),
+    ``FdrFJe`` (session_id), ``cfb2h`` (build_label). Regexes are per-site;
+    see ``notebooklm/core/auth.py:289-333`` and ``stitch/core/auth.py`` for
+    worked examples.
+
+    TODO: replace FILL_IN regex patterns and return keys below.
+    """
+    import re
+
+    import httpx
+
+    resp = httpx.get(
+        BASE_URL + "/",
+        cookies=cookies,
+        headers={
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            "Accept": "text/html,application/xhtml+xml",
+        },
+        follow_redirects=True,
+        timeout=15.0,
+    )
+    if "accounts.google.com" in str(resp.url):
+        raise AuthError("Session expired — run: cli-web-${app_name} auth login")
+
+    html = resp.text
+    m = re.search(r'"SNlM0e"\s*:\s*"([^"]+)"', html)
+    csrf = m.group(1) if m else None
+    if not csrf:
+        raise AuthError(
+            "Could not extract CSRF token. Session may have expired — "
+            "run: cli-web-${app_name} auth login"
+        )
+    return {"csrf": csrf}

--- a/cli-anything-web-plugin/templates/client_batchexecute.py.tpl
+++ b/cli-anything-web-plugin/templates/client_batchexecute.py.tpl
@@ -1,6 +1,8 @@
 """HTTP client for cli-web-${app_name} (Google batchexecute RPC)."""
 from __future__ import annotations
 
+from typing import Any, Optional
+
 import httpx
 
 from .exceptions import (
@@ -10,85 +12,128 @@ from .exceptions import (
     RPCError,
     raise_for_status,
 )
-from .rpc.encoder import encode_rpc
 from .rpc.decoder import decode_response
-from .rpc.types import RPCMethod
+from .rpc.encoder import build_url, encode_request
+from .rpc.types import BASE_URL, RPCMethod  # noqa: F401  (RPCMethod re-exported for callers)
 
 
 class ${AppName}Client:
-    """Google batchexecute RPC client."""
+    """Google batchexecute RPC client with transparent auth-token refresh.
 
-    BASE_URL = "https://FILL_IN_BASE_URL"
-    BATCHEXECUTE_PATH = "/_/FILL_IN_SERVICE/data/batchexecute"
+    Tokens (CSRF / session_id / build_label) are short-lived and re-fetched
+    from the homepage on every session. Cookies outlive tokens, so a 401/403
+    means tokens expired — refresh + retry once. See CLAUDE.md "Auth retry".
+    """
 
-    def __init__(self, cookies: dict | None = None):
+    def __init__(self, cookies: Optional[dict] = None):
         self._cookies = cookies or {}
-        self._csrf_token: str | None = None
-        self._session_id: str | None = None
+        self._csrf: Optional[str] = None
+        self._session_id: Optional[str] = None
+        self._build_label: Optional[str] = None
+        self._req_id = 100000
         self._client = httpx.Client(
-            base_url=self.BASE_URL,
+            base_url=BASE_URL,
             timeout=httpx.Timeout(connect=10.0, read=60.0, write=30.0, pool=30.0),
             headers={"User-Agent": "cli-web-${app_name}/0.1.0"},
         )
 
-    def _rpc(self, method: RPCMethod, params: list, retry_on_auth: bool = True) -> list:
-        """Execute an RPC call and return the decoded response.
+    # ------------------------------------------------------------------
+    # Request lifecycle
+    # ------------------------------------------------------------------
+
+    def _next_req_id(self) -> int:
+        self._req_id += 100000
+        return self._req_id
+
+    def _ensure_auth(self) -> None:
+        """Populate CSRF / session_id / build_label if not already cached."""
+        if self._csrf is None:
+            self._refresh_tokens()
+
+    def _rpc(
+        self,
+        rpc_id: str,
+        params: list,
+        source_path: str = "/",
+        retry_on_auth: bool = True,
+    ) -> Any:
+        """Execute a batchexecute RPC call and return the decoded result.
 
         Args:
-            method: The RPC method descriptor.
-            params: RPC params (encoded into ``f.req``).
-            retry_on_auth: If True, refresh tokens and retry once on 401/403.
-                           Set to False on the retry itself to avoid loops.
+            rpc_id: The RPC method identifier (from ``RPCMethod``).
+            params: RPC params (JSON-encoded into ``f.req``).
+            source_path: The ``source-path`` query param context.
+            retry_on_auth: If True, refresh tokens + retry once on 401/403.
         """
-        body = encode_rpc(method, params, csrf_token=self._csrf_token)
+        self._ensure_auth()
+
+        url = build_url(
+            rpc_id=rpc_id,
+            session_id=self._session_id or "",
+            build_label=self._build_label or "",
+            source_path=source_path,
+            req_id=self._next_req_id(),
+        )
+        body = encode_request(rpc_id, params, csrf_token=self._csrf or "")
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
         try:
-            resp = self._client.post(
-                self.BATCHEXECUTE_PATH,
-                data=body,
-                cookies=self._cookies,
-            )
+            resp = self._client.post(url, data=body, headers=headers, cookies=self._cookies)
         except httpx.ConnectError as exc:
             raise NetworkError(f"Connection failed: {exc}")
         except httpx.TimeoutException as exc:
             raise NetworkError(f"Request timed out: {exc}")
 
-        # Batchexecute tokens (CSRF / session_id / build_label) are short-lived
-        # but cookies outlive them — a 401/403 typically means tokens expired,
-        # not that cookies are bad. Refresh and retry once.
+        # Short-lived tokens expire before cookies — refresh + retry once.
         if resp.status_code in (401, 403) and retry_on_auth:
             self._refresh_tokens()
-            return self._rpc(method, params, retry_on_auth=False)
+            return self._rpc(rpc_id, params, source_path=source_path, retry_on_auth=False)
 
         raise_for_status(resp)
-        return decode_response(resp.text, method)
+        return decode_response(resp.text, rpc_id)
 
     def _refresh_tokens(self) -> None:
-        """Fetch homepage to extract fresh CSRF/session tokens.
+        """Fetch the homepage and extract fresh CSRF/session tokens.
 
-        Customize the regex patterns below for the target app. For Google
-        batchexecute apps the canonical extractors are ``SNlM0e`` (CSRF),
-        ``FdrFJe`` (session_id), and ``cfb2h`` (build_label) — see
-        ``stitch/core/auth.py`` or ``notebooklm/core/auth.py`` for worked
-        examples, and CLAUDE.md's "Auth cookie priority" section.
+        Default implementation extracts only ``SNlM0e`` (CSRF). Override or
+        extend for apps that also need ``FdrFJe`` (session_id) and
+        ``cfb2h`` (build_label). See stitch/core/auth.py and
+        notebooklm/core/auth.py for worked examples, plus CLAUDE.md's
+        "Auth cookie priority" section.
         """
         import re
+
         resp = self._client.get("/", cookies=self._cookies, follow_redirects=True)
         if resp.status_code != 200:
-            raise AuthError("Token refresh failed. Run: cli-web-${app_name} auth login", recoverable=False)
+            raise AuthError(
+                "Token refresh failed. Run: cli-web-${app_name} auth login",
+                recoverable=False,
+            )
         html = resp.text
         m = re.search(r'"SNlM0e"\s*:\s*"([^"]+)"', html)
         if m:
-            self._csrf_token = m.group(1)
-        # TODO: extract session_id (FdrFJe) and build_label (cfb2h) here too
-        # if your batchexecute URL needs them.
+            self._csrf = m.group(1)
+        m = re.search(r'"FdrFJe"\s*:\s*"(-?[0-9]+)"', html)
+        if m:
+            self._session_id = m.group(1)
+        m = re.search(r'"cfb2h"\s*:\s*"([^"]+)"', html)
+        if m:
+            self._build_label = m.group(1)
+
+        if not self._csrf:
+            raise AuthError(
+                "Could not extract CSRF token from homepage. Session may be "
+                "expired — run: cli-web-${app_name} auth login",
+                recoverable=False,
+            )
 
     # --- Add RPC method wrappers here ---
 
-    def close(self):
+    def close(self) -> None:
         self._client.close()
 
     def __enter__(self):
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args) -> None:
         self.close()

--- a/cli-anything-web-plugin/templates/client_batchexecute.py.tpl
+++ b/cli-anything-web-plugin/templates/client_batchexecute.py.tpl
@@ -31,8 +31,15 @@ class ${AppName}Client:
             headers={"User-Agent": "cli-web-${app_name}/0.1.0"},
         )
 
-    def _rpc(self, method: RPCMethod, params: list) -> list:
-        """Execute an RPC call and return the decoded response."""
+    def _rpc(self, method: RPCMethod, params: list, retry_on_auth: bool = True) -> list:
+        """Execute an RPC call and return the decoded response.
+
+        Args:
+            method: The RPC method descriptor.
+            params: RPC params (encoded into ``f.req``).
+            retry_on_auth: If True, refresh tokens and retry once on 401/403.
+                           Set to False on the retry itself to avoid loops.
+        """
         body = encode_rpc(method, params, csrf_token=self._csrf_token)
         try:
             resp = self._client.post(
@@ -45,20 +52,35 @@ class ${AppName}Client:
         except httpx.TimeoutException as exc:
             raise NetworkError(f"Request timed out: {exc}")
 
+        # Batchexecute tokens (CSRF / session_id / build_label) are short-lived
+        # but cookies outlive them — a 401/403 typically means tokens expired,
+        # not that cookies are bad. Refresh and retry once.
+        if resp.status_code in (401, 403) and retry_on_auth:
+            self._refresh_tokens()
+            return self._rpc(method, params, retry_on_auth=False)
+
         raise_for_status(resp)
         return decode_response(resp.text, method)
 
     def _refresh_tokens(self) -> None:
-        """Fetch homepage to extract fresh CSRF/session tokens."""
+        """Fetch homepage to extract fresh CSRF/session tokens.
+
+        Customize the regex patterns below for the target app. For Google
+        batchexecute apps the canonical extractors are ``SNlM0e`` (CSRF),
+        ``FdrFJe`` (session_id), and ``cfb2h`` (build_label) — see
+        ``stitch/core/auth.py`` or ``notebooklm/core/auth.py`` for worked
+        examples, and CLAUDE.md's "Auth cookie priority" section.
+        """
         import re
         resp = self._client.get("/", cookies=self._cookies, follow_redirects=True)
         if resp.status_code != 200:
             raise AuthError("Token refresh failed. Run: cli-web-${app_name} auth login", recoverable=False)
-        # Customize these regex patterns for the target app
         html = resp.text
         m = re.search(r'"SNlM0e"\s*:\s*"([^"]+)"', html)
         if m:
             self._csrf_token = m.group(1)
+        # TODO: extract session_id (FdrFJe) and build_label (cfb2h) here too
+        # if your batchexecute URL needs them.
 
     # --- Add RPC method wrappers here ---
 

--- a/cli-anything-web-plugin/templates/helpers_context.py.tpl
+++ b/cli-anything-web-plugin/templates/helpers_context.py.tpl
@@ -1,0 +1,29 @@
+
+
+# --- Persistent context (self-contained; no core.config dependency) ---
+import pathlib as _pathlib
+
+_CONTEXT_DIR = _pathlib.Path.home() / ".config" / "cli-web-${app_name}"
+_CONTEXT_FILE = _CONTEXT_DIR / "context.json"
+
+
+def get_context_value(key: str) -> str | None:
+    """Read a value from the persistent context file."""
+    import json as _json
+
+    if not _CONTEXT_FILE.exists():
+        return None
+    data = _json.loads(_CONTEXT_FILE.read_text())
+    return data.get(key)
+
+
+def set_context_value(key: str, value: str) -> None:
+    """Write a value to the persistent context file."""
+    import json as _json
+
+    _CONTEXT_DIR.mkdir(parents=True, exist_ok=True)
+    data = {}
+    if _CONTEXT_FILE.exists():
+        data = _json.loads(_CONTEXT_FILE.read_text())
+    data[key] = value
+    _CONTEXT_FILE.write_text(_json.dumps(data, indent=2))

--- a/cli-anything-web-plugin/templates/helpers_partial_ids.py.tpl
+++ b/cli-anything-web-plugin/templates/helpers_partial_ids.py.tpl
@@ -1,0 +1,16 @@
+
+
+def resolve_partial_id(partial: str, items: list[dict], key: str = "id") -> dict:
+    """Resolve a partial ID prefix to a single item.
+
+    Raises ${AppName}Error if zero or multiple matches.
+    """
+    from ..core.exceptions import ${AppName}Error
+
+    matches = [item for item in items if str(item.get(key, "")).startswith(partial)]
+    if len(matches) == 0:
+        raise ${AppName}Error(f"No item found matching '{partial}'")
+    if len(matches) > 1:
+        ids = [str(m.get(key, "")) for m in matches[:5]]
+        raise ${AppName}Error(f"Ambiguous ID '{partial}', matches: {', '.join(ids)}")
+    return matches[0]

--- a/cli-anything-web-plugin/templates/helpers_polling.py.tpl
+++ b/cli-anything-web-plugin/templates/helpers_polling.py.tpl
@@ -1,0 +1,39 @@
+
+
+def poll_until_complete(
+    check_fn,
+    *,
+    timeout: float = 300.0,
+    initial_delay: float = 2.0,
+    max_delay: float = 10.0,
+    backoff_factor: float = 1.5,
+):
+    """Poll check_fn with exponential backoff until it returns a truthy value.
+
+    Args:
+        check_fn: Callable that returns a result (truthy = done) or None/falsy.
+        timeout: Maximum total wait time in seconds.
+        initial_delay: First sleep interval.
+        max_delay: Cap on sleep interval.
+        backoff_factor: Multiplier per iteration.
+
+    Returns:
+        The truthy result from check_fn.
+
+    Raises:
+        ${AppName}Error if timeout is exceeded.
+    """
+    import time
+
+    from ..core.exceptions import ${AppName}Error
+
+    elapsed = 0.0
+    delay = initial_delay
+    while elapsed < timeout:
+        result = check_fn()
+        if result:
+            return result
+        time.sleep(delay)
+        elapsed += delay
+        delay = min(delay * backoff_factor, max_delay)
+    raise ${AppName}Error(f"Operation timed out after {timeout}s")

--- a/cli-anything-web-plugin/templates/rpc_decoder.py.tpl
+++ b/cli-anything-web-plugin/templates/rpc_decoder.py.tpl
@@ -1,48 +1,104 @@
-"""Decode batchexecute RPC responses.
+"""Response decoder for Google batchexecute RPC protocol.
 
-Google batchexecute responses have a prefix line (e.g., )]}'\\n) followed
-by length-prefixed JSON arrays. This module strips the prefix and parses
-the inner payload.
+Production-parity implementation: handles multi-chunk responses, anti-XSSI
+prefix, length-hint lines, and typed ``"er"`` error entries.
 """
 from __future__ import annotations
 
 import json
+from typing import Any
 
-from ..exceptions import RPCError
-from .types import RPCMethod
+from ..exceptions import AuthError, RPCError
 
 
-def decode_response(raw: str, method: RPCMethod) -> list:
-    """Decode a batchexecute response and return the inner payload.
+def strip_prefix(data: "str | bytes") -> str:
+    """Remove the anti-XSSI ``)]}'`` prefix from a batchexecute response.
 
-    Args:
-        raw: The full response text from batchexecute endpoint.
-        method: The RPC method that was called (for error context).
+    Returns a decoded ``str``. Batchexecute chunk lengths are JavaScript
+    ``String.length`` values (UTF-16 code units / Unicode code points for
+    BMP), not UTF-8 byte counts — all subsequent processing must use ``str``,
+    not ``bytes``.
+    """
+    if isinstance(data, bytes):
+        text = data.decode("utf-8", errors="replace")
+    else:
+        text = data
+    if text.startswith(")]}'"):
+        text = text[4:].lstrip("\n")
+    return text
 
-    Returns:
-        Parsed inner JSON array from the RPC response.
+
+def parse_chunks(text: str) -> list[str]:
+    """Extract all JSON arrays from a batchexecute response body.
+
+    The body contains JSON arrays interspersed with length-hint numbers.
+    Rather than trusting the length hints, use ``json.JSONDecoder.raw_decode``
+    to find every JSON array in the stream, skipping numeric lines::
+
+        11927\\n
+        [["wrb.fr", "wXbhsf", "..."]]\\n
+        59\\n
+        [["di", 157], ["af.httprm", ...]]\\n
+        27\\n
+        [["e", 4, null, null, 12542]]
+    """
+    chunks: list[str] = []
+    decoder = json.JSONDecoder()
+    pos = 0
+    while pos < len(text):
+        ch = text[pos]
+        if ch in " \t\r\n":
+            pos += 1
+            continue
+        if ch.isdigit():
+            while pos < len(text) and text[pos] != "\n":
+                pos += 1
+            continue
+        if ch == "[":
+            try:
+                _, end = decoder.raw_decode(text, pos)
+                chunks.append(text[pos:end])
+                pos = end
+                continue
+            except json.JSONDecodeError:
+                pass
+        pos += 1
+    return chunks
+
+
+def extract_result(chunks: list[str], rpc_id: str) -> Any:
+    """Find and decode the result for a specific RPC method.
 
     Raises:
-        RPCError: If the response cannot be parsed.
+        AuthError: If the response carries an auth-related error code.
+        RPCError: If the response carries any other error code or the RPC id
+            is not present in any chunk.
     """
-    # Strip the security prefix
-    lines = raw.split("\n")
-    for i, line in enumerate(lines):
-        if line.strip().startswith("[["):
-            break
-    else:
-        raise RPCError(f"Cannot parse batchexecute response for {method.value[0]}")
+    for chunk in chunks:
+        try:
+            outer = json.loads(chunk)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        for entry in outer:
+            if not isinstance(entry, list) or len(entry) < 2:
+                continue
+            if entry[0] == "er":
+                err_code = entry[1] if len(entry) > 1 else None
+                if err_code in (7, 9):
+                    raise AuthError(
+                        f"Auth error (code {err_code}) — run: cli-web-${app_name} auth login"
+                    )
+                raise RPCError(f"RPC error code {err_code}")
+            if entry[0] == "wrb.fr" and entry[1] == rpc_id:
+                raw = entry[2]
+                if raw is None:
+                    return None
+                return json.loads(raw)
+    raise RPCError(f"RPC result for {rpc_id!r} not found in response")
 
-    try:
-        outer = json.loads(lines[i])
-    except json.JSONDecodeError as exc:
-        raise RPCError(f"JSON decode failed for {method.value[0]}: {exc}")
 
-    # Navigate to inner payload: outer[0][2] contains the JSON string
-    try:
-        inner_str = outer[0][2]
-        if isinstance(inner_str, str):
-            return json.loads(inner_str)
-        return inner_str
-    except (IndexError, TypeError, json.JSONDecodeError) as exc:
-        raise RPCError(f"Inner payload extraction failed for {method.value[0]}: {exc}")
+def decode_response(data: "str | bytes", rpc_id: str) -> Any:
+    """Full decode pipeline: strip prefix → parse chunks → extract result."""
+    text = strip_prefix(data)
+    chunks = parse_chunks(text)
+    return extract_result(chunks, rpc_id)

--- a/cli-anything-web-plugin/templates/rpc_encoder.py.tpl
+++ b/cli-anything-web-plugin/templates/rpc_encoder.py.tpl
@@ -1,30 +1,55 @@
-"""Encode RPC requests for Google batchexecute.
-
-Builds the f.req form body expected by /_/SERVICE/data/batchexecute.
-"""
+"""Request encoder for Google batchexecute RPC protocol."""
 from __future__ import annotations
 
 import json
+import urllib.parse
 
-from .types import RPCMethod
+from .types import BATCHEXECUTE_URL
 
 
-def encode_rpc(
-    method: RPCMethod,
-    params: list,
-    *,
-    csrf_token: str | None = None,
-) -> dict:
-    """Encode an RPC call into a batchexecute form body.
+def encode_request(rpc_id: str, params: list, csrf_token: str) -> str:
+    """Encode a batchexecute request body.
 
-    Returns a dict suitable for httpx data= parameter.
+    Args:
+        rpc_id: The RPC method identifier (e.g., ``'wXbhsf'``).
+        params: The method parameters as a Python list.
+        csrf_token: The CSRF token (``SNlM0e`` from ``WIZ_global_data``).
+
+    Returns:
+        URL-encoded form body string ready for POST (``Content-Type:
+        application/x-www-form-urlencoded``).
     """
-    rpc_id = method.value[0]
-    inner = json.dumps(params, separators=(",", ":"))
-    req_body = json.dumps([[
-        [rpc_id, inner, None, "generic"],
-    ]], separators=(",", ":"))
-    body = {"f.req": req_body}
-    if csrf_token:
-        body["at"] = csrf_token
-    return body
+    inner = [rpc_id, json.dumps(params), None, "generic"]
+    freq = json.dumps([[inner]])
+    return urllib.parse.urlencode({"f.req": freq, "at": csrf_token})
+
+
+def build_url(
+    rpc_id: str,
+    session_id: str,
+    build_label: str = "",
+    source_path: str = "/",
+    req_id: int = 100000,
+    lang: str = "en",
+) -> str:
+    """Build the batchexecute URL with query parameters.
+
+    Args:
+        rpc_id: The RPC method identifier.
+        session_id: The ``f.sid`` value (``FdrFJe`` from ``WIZ_global_data``).
+        build_label: The ``bl`` value (``cfb2h``) — optional.
+        source_path: The current page context path (sent as ``source-path``).
+        req_id: Incrementing request counter; start at 100000.
+        lang: Language code (``hl`` param).
+    """
+    params: dict[str, str] = {
+        "rpcids": rpc_id,
+        "source-path": source_path,
+        "f.sid": session_id,
+        "hl": lang,
+        "rt": "c",
+        "_reqid": str(req_id),
+    }
+    if build_label:
+        params["bl"] = build_label
+    return f"{BATCHEXECUTE_URL}?{urllib.parse.urlencode(params)}"

--- a/cli-anything-web-plugin/templates/rpc_types.py.tpl
+++ b/cli-anything-web-plugin/templates/rpc_types.py.tpl
@@ -1,20 +1,25 @@
-"""RPC method definitions for cli-web-${app_name}.
+"""RPC method identifiers for cli-web-${app_name} batchexecute.
 
-Each method maps to a batchexecute RPC ID discovered from traffic capture.
-IMPORTANT: Verify every RPC ID against captured traffic. The same endpoint
-may use different param structures for different operations.
+When Google rotates RPC IDs, update this file as the single source of truth.
+Verify every RPC ID against captured traffic — the same endpoint may serve
+multiple operations with different param structures.
 """
 from __future__ import annotations
 
-from enum import Enum
+# TODO: replace with the real batchexecute URL from traffic analysis.
+# Typical shape: https://<app>.google.com/_/<ServiceName>/data/batchexecute
+BATCHEXECUTE_URL = "https://FILL_IN_HOST/_/FILL_IN_SERVICE/data/batchexecute"
+BASE_URL = "https://FILL_IN_HOST"
 
 
-class RPCMethod(Enum):
-    """Known RPC methods.
+class RPCMethod:
+    """RPC method IDs discovered from network traffic analysis.
 
-    Format: NAME = ("rpc_id", "human_description")
-    Fill in from <APP>.md after traffic analysis.
+    Add each ID as a class attribute. Example::
+
+        LIST_THINGS = "wXbhsf"
+        CREATE_THING = "CCqFvf"
     """
 
-    # EXAMPLE = ("AbCdEf", "Example operation description")
-    pass
+    # Fill these in after parsing the analyze-traffic.json output.
+    EXAMPLE = "FILL_IN_RPC_ID"

--- a/cli-anything-web-plugin/templates/setup.py.tpl
+++ b/cli-anything-web-plugin/templates/setup.py.tpl
@@ -13,9 +13,7 @@ setup(
         "rich>=13.0",
         "prompt_toolkit>=3.0",
     ],
-    extras_require={
-        ${extras_require}
-    },
+    ${extras_require_block}
     entry_points={
         "console_scripts": [
             "cli-web-${app_name}=cli_web.${app_name_underscore}.${app_name_underscore}_cli:main",

--- a/cli-anything-web-plugin/verify-plugin.sh
+++ b/cli-anything-web-plugin/verify-plugin.sh
@@ -44,7 +44,7 @@ check "scripts/repl_skin.py exists" "$([ -f "$SCRIPT_DIR/scripts/repl_skin.py" ]
 check "scripts/parse-trace.py exists" "$([ -f "$SCRIPT_DIR/scripts/parse-trace.py" ] && echo true || echo false)"
 
 # Pipeline automation scripts
-for script in scaffold-cli.py validate-checklist.py generate-test-docs.py smoke-test.py run-pipeline.py; do
+for script in scaffold-cli.py validate-checklist.py generate-test-docs.py smoke-test.py run-pipeline.py validate-capture.py; do
     check "scripts/$script exists" "$([ -f "$SCRIPT_DIR/scripts/$script" ] && echo true || echo false)"
 done
 

--- a/cli-anything-web-plugin/verify-plugin.sh
+++ b/cli-anything-web-plugin/verify-plugin.sh
@@ -44,9 +44,17 @@ check "scripts/repl_skin.py exists" "$([ -f "$SCRIPT_DIR/scripts/repl_skin.py" ]
 check "scripts/parse-trace.py exists" "$([ -f "$SCRIPT_DIR/scripts/parse-trace.py" ] && echo true || echo false)"
 
 # Pipeline automation scripts
-for script in scaffold-cli.py validate-checklist.py generate-test-docs.py smoke-test.py; do
+for script in scaffold-cli.py validate-checklist.py generate-test-docs.py smoke-test.py run-pipeline.py; do
     check "scripts/$script exists" "$([ -f "$SCRIPT_DIR/scripts/$script" ] && echo true || echo false)"
 done
+
+# Shared script utility modules
+for mod in plugin_paths.py traffic_utils.py state_utils.py; do
+    check "scripts/$mod exists" "$([ -f "$SCRIPT_DIR/scripts/$mod" ] && echo true || echo false)"
+done
+
+# Script tests
+check "scripts/tests/ exists" "$([ -d "$SCRIPT_DIR/scripts/tests" ] && echo true || echo false)"
 
 # scripts/setup.sh executable
 if [ -f "$SCRIPT_DIR/scripts/setup.sh" ] && [ -x "$SCRIPT_DIR/scripts/setup.sh" ]; then


### PR DESCRIPTION
Consolidate duplicated logic across plugin scripts into three shared modules
and add the first test suite for the pipeline's critical scripts.

New modules:
- scripts/plugin_paths.py: canonical path discovery (get_plugin_root, etc.)
- scripts/traffic_utils.py: merged NOISE_PATTERNS + is_noise_url + is_static_asset
  + normalize_headers (replaces two divergent implementations in
  analyze-traffic.py and mitmproxy-capture.py)
- scripts/state_utils.py: load_json_state/save_json_state/utc_now_iso
  (shared by phase-state.py and capture-checkpoint.py)
- scripts/run-pipeline.py: orchestrator with `status`, `parse`, `validate`
  subcommands for a single next-action view across the 4-phase pipeline

scaffold-cli.py hardening:
- Placeholder validator catches unresolved ${name} before writing any file
- render_template now raises if variables are missing
- Fragile manual .replace("${AppName}", ...) in build_client() replaced
  with uniform render_string() pipeline

Tests (scripts/tests/, 72 pytest cases):
- test_scaffold_cli.py: placeholder rendering, validation, 4-variant E2E scaffold
- test_parse_trace.py: .network parsing, static-asset filtering, latest-only
- test_analyze_traffic.py: protocol detection, noise filtering, end-to-end analyze()
- test_traffic_utils.py, test_state_utils.py, test_plugin_paths.py,
  test_run_pipeline.py: coverage for new modules

HARNESS.md:
- Complete scripts reference table (14 scripts documented)
- New "Shared Script Utilities" table
- New "Pipeline Anatomy" table mapping skills to scripts per phase

verify-plugin.sh extended to check new modules + tests/ exist.

Net line delta: -182/+137 across modified files; duplication reduced
substantially in analyze-traffic.py (-54 LOC) and mitmproxy-capture.py (-91 LOC).

https://claude.ai/code/session_01FSCxUeRjvPF9ekksaFpuf4