### PR TITLE
refactor(mcp): run each tool call as a subprocess instead of in-process

### DIFF
--- a/airbnb/agent-harness/.manifest.json
+++ b/airbnb/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/airbnb/agent-harness/cli_web/airbnb/utils/mcp_server.py
+++ b/airbnb/agent-harness/cli_web/airbnb/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/amazon/agent-harness/.manifest.json
+++ b/amazon/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/amazon/agent-harness/cli_web/amazon/utils/mcp_server.py
+++ b/amazon/agent-harness/cli_web/amazon/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/booking/agent-harness/.manifest.json
+++ b/booking/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/booking/agent-harness/cli_web/booking/utils/mcp_server.py
+++ b/booking/agent-harness/cli_web/booking/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/capitoltrades/agent-harness/.manifest.json
+++ b/capitoltrades/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/capitoltrades/agent-harness/cli_web/capitoltrades/utils/mcp_server.py
+++ b/capitoltrades/agent-harness/cli_web/capitoltrades/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/chatgpt/agent-harness/.manifest.json
+++ b/chatgpt/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/chatgpt/agent-harness/cli_web/chatgpt/utils/mcp_server.py
+++ b/chatgpt/agent-harness/cli_web/chatgpt/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/cli-anything-web-plugin/scripts/mcp_server.py
+++ b/cli-anything-web-plugin/scripts/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/cli-anything-web-plugin/templates/cli_entry.py.tpl
+++ b/cli-anything-web-plugin/templates/cli_entry.py.tpl
@@ -106,7 +106,7 @@ from cli_web.${app_name_underscore} import __version__ as _pkg_version  # noqa: 
 from cli_web.${app_name_underscore}.utils.doctor import register_doctor_command  # noqa: E402
 from cli_web.${app_name_underscore}.utils.mcp_server import register_mcp_command  # noqa: E402
 
-register_mcp_command(cli, app_name="${app_name}", version=_pkg_version)
+register_mcp_command(cli, app_name="${app_name}", version=_pkg_version, pkg="${app_name_underscore}")
 register_doctor_command(cli, app_name="${app_name}", pkg="${app_name_underscore}")
 
 

--- a/cli-web-core/cli_web_core/mcp_server.py
+++ b/cli-web-core/cli_web_core/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/cli-web-core/tests/test_mcp_server.py
+++ b/cli-web-core/tests/test_mcp_server.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 import click
 import pytest
@@ -49,7 +50,20 @@ def demo_cli():
 
 @pytest.fixture()
 def server(demo_cli):
-    return McpServer(demo_cli, app_name="demo", version="9.9.9")
+    """Server whose tool calls run the in-memory demo CLI via CliRunner.
+
+    Production uses a fresh subprocess per call (see the subprocess tests
+    below); the in-memory executor lets these protocol/argv/shaping tests
+    exercise the demo group without an installed binary.
+    """
+    from click.testing import CliRunner
+
+    def executor(argv):
+        result = CliRunner().invoke(demo_cli, argv, catch_exceptions=True)
+        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        return (text, result.exit_code != 0)
+
+    return McpServer(demo_cli, app_name="demo", version="9.9.9", executor=executor)
 
 
 def test_initialize_handshake(server):
@@ -165,3 +179,100 @@ def test_multi_value_params_call(server):
     payload = json.loads(resp["result"]["content"][0]["text"])
     assert payload["data"]["query"] == ["python", "tutorial"]
     assert payload["data"]["tags"] == ["a", "b"]
+
+
+# ── subprocess-per-call execution (the production default) ───────────────────
+
+
+def _call(server, name, arguments=None):
+    return server.handle(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments or {}},
+        }
+    )
+
+
+def test_default_execution_spawns_a_subprocess(demo_cli, monkeypatch):
+    """With no executor injected, each tool call shells out to a fresh process."""
+    import subprocess
+
+    seen = {}
+
+    class _Proc:
+        stdout = '{"success": true, "data": []}'
+        stderr = ""
+        returncode = 0
+
+    def fake_run(command, **kwargs):
+        seen["command"] = command
+        seen["kwargs"] = kwargs
+        return _Proc()
+
+    monkeypatch.setattr("shutil.which", lambda _name: None)  # force python -m
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    server = McpServer(demo_cli, app_name="demo", pkg="demo_pkg")
+    resp = _call(server, "things_list", {"limit": 2})
+
+    # The whole command line is: python -m cli_web.demo_pkg things list --limit 2 --json
+    assert seen["command"][:3] == [sys.executable, "-m", "cli_web.demo_pkg"]
+    assert seen["command"][3:5] == ["things", "list"]
+    assert "--json" in seen["command"]
+    assert seen["kwargs"]["timeout"] == server.timeout
+    assert resp["result"]["isError"] is False
+    assert json.loads(resp["result"]["content"][0]["text"]) == {"success": True, "data": []}
+
+
+def test_subprocess_prefers_installed_binary(demo_cli, monkeypatch):
+    import subprocess
+
+    seen = {}
+
+    class _Proc:
+        stdout = "{}"
+        stderr = ""
+        returncode = 0
+
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/local/bin/{name}")
+    monkeypatch.setattr(
+        subprocess, "run", lambda command, **kw: seen.update(command=command) or _Proc()
+    )
+
+    McpServer(demo_cli, app_name="demo").handle(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "boom"}}
+    )
+    assert seen["command"][0] == "/usr/local/bin/cli-web-demo"
+    assert "-m" not in seen["command"]
+
+
+def test_subprocess_nonzero_exit_is_error_and_prefers_stderr(demo_cli, monkeypatch):
+    import subprocess
+
+    class _Proc:
+        stdout = ""
+        stderr = "Usage: ... \nError: no such option"
+        returncode = 2
+
+    monkeypatch.setattr("shutil.which", lambda _name: "/bin/cli-web-demo")
+    monkeypatch.setattr(subprocess, "run", lambda command, **kw: _Proc())
+
+    resp = _call(McpServer(demo_cli, app_name="demo"), "things_list")
+    assert resp["result"]["isError"] is True
+    assert "no such option" in resp["result"]["content"][0]["text"]
+
+
+def test_subprocess_timeout_returns_error(demo_cli, monkeypatch):
+    import subprocess
+
+    def boom(command, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=command, timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr("shutil.which", lambda _name: "/bin/cli-web-demo")
+    monkeypatch.setattr(subprocess, "run", boom)
+
+    resp = _call(McpServer(demo_cli, app_name="demo", timeout=7.0), "things_list")
+    assert resp["result"]["isError"] is True
+    assert "timed out after 7.0s" in resp["result"]["content"][0]["text"]

--- a/codewiki/agent-harness/.manifest.json
+++ b/codewiki/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/codewiki/agent-harness/cli_web/codewiki/utils/mcp_server.py
+++ b/codewiki/agent-harness/cli_web/codewiki/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/futbin/agent-harness/.manifest.json
+++ b/futbin/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/futbin/agent-harness/cli_web/futbin/utils/mcp_server.py
+++ b/futbin/agent-harness/cli_web/futbin/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/gai/agent-harness/.manifest.json
+++ b/gai/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/gai/agent-harness/cli_web/gai/utils/mcp_server.py
+++ b/gai/agent-harness/cli_web/gai/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/gh-trending/agent-harness/.manifest.json
+++ b/gh-trending/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/gh-trending/agent-harness/cli_web/gh_trending/utils/mcp_server.py
+++ b/gh-trending/agent-harness/cli_web/gh_trending/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/hackernews/agent-harness/.manifest.json
+++ b/hackernews/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/hackernews/agent-harness/cli_web/hackernews/utils/mcp_server.py
+++ b/hackernews/agent-harness/cli_web/hackernews/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/linkedin/agent-harness/.manifest.json
+++ b/linkedin/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/linkedin/agent-harness/cli_web/linkedin/utils/mcp_server.py
+++ b/linkedin/agent-harness/cli_web/linkedin/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/notebooklm/agent-harness/.manifest.json
+++ b/notebooklm/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/notebooklm/agent-harness/cli_web/notebooklm/utils/mcp_server.py
+++ b/notebooklm/agent-harness/cli_web/notebooklm/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/pexels/agent-harness/.manifest.json
+++ b/pexels/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/pexels/agent-harness/cli_web/pexels/utils/mcp_server.py
+++ b/pexels/agent-harness/cli_web/pexels/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/producthunt/agent-harness/.manifest.json
+++ b/producthunt/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/producthunt/agent-harness/cli_web/producthunt/utils/mcp_server.py
+++ b/producthunt/agent-harness/cli_web/producthunt/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/reddit/agent-harness/.manifest.json
+++ b/reddit/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/reddit/agent-harness/cli_web/reddit/utils/mcp_server.py
+++ b/reddit/agent-harness/cli_web/reddit/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/stitch/agent-harness/.manifest.json
+++ b/stitch/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/stitch/agent-harness/cli_web/stitch/utils/mcp_server.py
+++ b/stitch/agent-harness/cli_web/stitch/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/tests/contract/test_mcp.py
+++ b/tests/contract/test_mcp.py
@@ -52,3 +52,47 @@ def test_mcp_serve_handshake(entry):
         assert tool["inputSchema"]["type"] == "object"
         # json flag is forced by the adapter, never exposed
         assert "json_mode" not in tool["inputSchema"]["properties"]
+
+
+# Drive a real tools/call: every CLI registers the offline `doctor` command,
+# so calling it exercises the full subprocess-per-call path end to end without
+# touching the network. id=2 calls doctor; id=3 calls a bogus tool.
+_TOOLS_CALL = (
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}\n'
+    '{"jsonrpc":"2.0","method":"notifications/initialized"}\n'
+    '{"jsonrpc":"2.0","id":2,"method":"tools/call",'
+    '"params":{"name":"doctor","arguments":{}}}\n'
+    '{"jsonrpc":"2.0","id":3,"method":"tools/call",'
+    '"params":{"name":"no_such_tool_xyz","arguments":{}}}\n'
+)
+
+
+@pytest.mark.parametrize("entry", [pytest.param(e, id=e.name) for e in REGISTRY.clis])
+def test_mcp_tools_call_spawns_subprocess(entry):
+    cmd = resolve_cli(entry.name)
+    proc = subprocess.run(
+        [*cmd, "mcp-serve"],
+        input=_TOOLS_CALL,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    by_id = {}
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        msg = json.loads(line)
+        if msg.get("id") is not None:
+            by_id[msg["id"]] = msg
+
+    # The `doctor` tool ran (as a fresh subprocess) and returned its --json envelope.
+    assert 2 in by_id, (
+        f"{entry.name}: no doctor response: {proc.stdout[:300]!r} / {proc.stderr[:300]!r}"
+    )
+    result = by_id[2]["result"]
+    assert "content" in result and result["content"][0]["type"] == "text"
+    payload = json.loads(result["content"][0]["text"])
+    assert "data" in payload and "checks" in payload["data"], f"{entry.name}: not a doctor envelope"
+
+    # An unknown tool is a JSON-RPC error, not a crash.
+    assert 3 in by_id and by_id[3]["error"]["code"] == -32602

--- a/tripadvisor/agent-harness/.manifest.json
+++ b/tripadvisor/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/tripadvisor/agent-harness/cli_web/tripadvisor/utils/mcp_server.py
+++ b/tripadvisor/agent-harness/cli_web/tripadvisor/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/unsplash/agent-harness/.manifest.json
+++ b/unsplash/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/unsplash/agent-harness/cli_web/unsplash/utils/mcp_server.py
+++ b/unsplash/agent-harness/cli_web/unsplash/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps

--- a/youtube/agent-harness/.manifest.json
+++ b/youtube/agent-harness/.manifest.json
@@ -13,17 +13,17 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
-      "sha256": "e2d018c4fa7775cd213472abf581af183355fffb6b47d5c9fc5e1c2d64b6316c",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-06-10T12:05:01Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T11:09:00Z"
+      "synced_at": "2026-06-10T12:05:01Z"
     }
   },
   "overrides": []

--- a/youtube/agent-harness/cli_web/youtube/utils/mcp_server.py
+++ b/youtube/agent-harness/cli_web/youtube/utils/mcp_server.py
@@ -6,9 +6,13 @@ Vendored into every generated CLI at cli_web/<app>/utils/mcp_server.py by
 
 Every cli-web-* command already speaks ``--json``, so the Click command
 tree maps 1:1 onto MCP tools: tool names are ``group_subcommand``, input
-schemas are derived from Click parameters, and calls run the command
-in-process with ``--json`` forced, returning the JSON envelope as the tool
-result. Transport: MCP stdio (newline-delimited JSON-RPC 2.0).
+schemas are derived from Click parameters, and each ``tools/call`` spawns
+the CLI as a fresh subprocess with ``--json`` forced, returning the JSON
+envelope as the tool result. Spawning per call (rather than running
+in-process) gives every tool the same clean-process isolation as a normal
+CLI invocation — no auth/session/global state leaks between calls, and a
+wedged command cannot hang the server. Transport: MCP stdio
+(newline-delimited JSON-RPC 2.0).
 
 Usage (wired automatically into generated CLIs)::
 
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import Any
 
 PROTOCOL_VERSION = "2024-11-05"
@@ -129,10 +134,27 @@ def _cmd_supports_json(cmd: Any) -> bool:
 
 
 class McpServer:
-    def __init__(self, cli: Any, app_name: str, version: str = "0.1.0"):
+    def __init__(
+        self,
+        cli: Any,
+        app_name: str,
+        version: str = "0.1.0",
+        pkg: str | None = None,
+        *,
+        timeout: float = 300.0,
+        executor: Callable[[list[str]], tuple[str, bool]] | None = None,
+    ):
         self.cli = cli
         self.app_name = app_name
         self.version = version
+        #: Namespace sub-package, for the ``python -m`` subprocess fallback.
+        self.pkg = pkg or app_name.replace("-", "_")
+        #: Per-call subprocess timeout (seconds).
+        self.timeout = timeout
+        #: Optional ``(argv) -> (text, is_error)`` override. Defaults to a
+        #: fresh subprocess per call; injected in tests to run an in-memory
+        #: Click group without an installed binary.
+        self._executor = executor
         self._leaves: dict[str, tuple[tuple[str, ...], Any]] = {}
         for path, cmd in _iter_leaf_commands(cli):
             tool_name = "_".join(path).replace("-", "_")
@@ -174,18 +196,57 @@ class McpServer:
         arguments = params.get("arguments") or {}
         argv = _build_argv(path, cmd, arguments, json_flag=_cmd_supports_json(cmd))
 
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(self.cli, argv, catch_exceptions=True)
-        text = result.output.strip() or (str(result.exception) if result.exception else "")
+        executor = self._executor or self._subprocess_execute
+        text, is_error = executor(argv)
         return self._result(
             msg_id,
             {
                 "content": [{"type": "text", "text": text}],
-                "isError": result.exit_code != 0,
+                "isError": is_error,
             },
         )
+
+    # ── command execution ────────────────────────────────────────────
+
+    def _base_command(self) -> list[str]:
+        """Resolve how to invoke this CLI as a subprocess.
+
+        Prefer the installed console script; fall back to ``python -m`` so the
+        server still works from a source checkout without ``pip install``.
+        """
+        import shutil
+
+        binary = shutil.which(f"cli-web-{self.app_name}")
+        if binary:
+            return [binary]
+        return [sys.executable, "-m", f"cli_web.{self.pkg}"]
+
+    def _subprocess_execute(self, argv: list[str]) -> tuple[str, bool]:
+        """Run one tool call as a fresh subprocess — full process isolation.
+
+        Each call is a clean process, identical to how a user (and the test
+        suite) invokes the CLI, so no auth/session/global state leaks between
+        calls and a stuck command cannot wedge the server.
+        """
+        import subprocess
+
+        command = [*self._base_command(), *argv]
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (f"command timed out after {self.timeout}s", True)
+        except (FileNotFoundError, OSError) as exc:
+            return (f"failed to run cli-web-{self.app_name}: {exc}", True)
+        # The --json success and error envelopes both go to stdout; fall back
+        # to stderr for hard failures (e.g. a Click usage error, exit 2).
+        text = proc.stdout.strip() or proc.stderr.strip()
+        return (text, proc.returncode != 0)
 
     @staticmethod
     def _result(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -215,13 +276,15 @@ class McpServer:
                 print(json.dumps(response), flush=True)
 
 
-def register_mcp_command(cli: Any, app_name: str, version: str = "0.1.0") -> None:
+def register_mcp_command(
+    cli: Any, app_name: str, version: str = "0.1.0", pkg: str | None = None
+) -> None:
     """Attach an ``mcp-serve`` command to a cli-web-* Click group."""
     import click
 
     @cli.command("mcp-serve", hidden=False)
     def mcp_serve() -> None:
         """Serve this CLI as an MCP server over stdio (newline JSON-RPC)."""
-        McpServer(cli, app_name=app_name, version=version).serve_stdio()
+        McpServer(cli, app_name=app_name, version=version, pkg=pkg).serve_stdio()
 
     _ = click  # imported for parity with vendored runtime deps


### PR DESCRIPTION
## What this does

The `mcp-serve` adapter ran every `tools/call` **in-process** via Click's `CliRunner`, inside the long-lived server process. That meant module-level state — the REPL skin, cached auth/session, HTTP clients — was shared across calls: state bleed and resource leaks the one-shot CLI path never exercises, plus no bound on a wedged command.

Each tool call now runs as a **fresh subprocess** (`cli-web-<app> … --json`, or `python -m cli_web.<pkg>` when the binary isn't on PATH), giving every tool the same clean-process isolation as a normal CLI invocation, with a per-call timeout so a stuck command can't hang the server. Behavior is otherwise identical: stdout carries the success/error envelope, stderr is the fallback for hard failures (e.g. a Click usage error).

This follows the project's principle that **the CLI is the product and MCP is a thin access layer over it** — running the real CLI per call keeps the two paths behaviorally identical instead of maintaining a divergent in-process execution model.

## Changes

- **`cli-web-core/cli_web_core/mcp_server.py`** (resynced to all 20 vendored copies): `McpServer` gains `pkg`/`timeout` and an injectable `executor` (subprocess by default). Installed-binary resolution with a `python -m` fallback. Entry-point template passes `pkg` for the fallback.
- **Unit tests**: existing protocol/argv/shaping tests run the in-memory demo CLI via an injected `CliRunner` executor (no install needed); new tests cover the subprocess path — binary-vs-`python -m` resolution, nonzero-exit/stderr fallback, and timeout.
- **Contract test** (`tests/contract/test_mcp.py`): drives a real `mcp-serve` and calls the offline `doctor` tool, asserting the full subprocess-per-call path end to end, plus an unknown-tool JSON-RPC error.

## Verification

- 702 unit tests pass (4 new); `ruff format --check` + `ruff check` clean repo-wide; `cli-web-devkit drift` → 60 ok / 0.
- Ran both contract tests against a real installed `cli-web-gh-trending` — pass. Live MCP session: the `doctor` tool returned a 5-check envelope with `isError: False`; a bogus tool returned `-32602 Unknown tool`.
