### PR TITLE
feat(devkit): keep the GitHub About CLI count in sync with the fleet

### DIFF
--- a/.github/workflows/about-sync.yml
+++ b/.github/workflows/about-sync.yml
@@ -1,0 +1,38 @@
+name: Sync About count
+
+# Auto-update the GitHub "About" description's CLI count whenever the fleet
+# changes. Editing repo metadata needs Administration:write, which the default
+# GITHUB_TOKEN lacks — so this uses a maintainer-provided fine-grained PAT
+# stored as the REPO_ADMIN_TOKEN secret. Until that secret exists this job
+# no-ops; the `about --check` step in tests.yml still flags drift in the
+# meantime.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - registry.json
+
+permissions:
+  contents: read
+
+jobs:
+  about-sync:
+    name: sync About CLI count
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Apply About description from registry.json
+        env:
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "REPO_ADMIN_TOKEN not set — skipping auto-apply."
+            echo "Create a fine-grained PAT (Administration: write) and add it"
+            echo "as the REPO_ADMIN_TOKEN secret to enable hands-off updates."
+            exit 0
+          fi
+          PYTHONPATH=devkit python -m cli_web_devkit about --apply

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,14 @@ jobs:
         run: python devkit/cli_web_devkit/registry_check.py
       - name: README fleet sections freshness
         run: PYTHONPATH=devkit python -m cli_web_devkit docs --check
+      - name: About description CLI count freshness
+        # Read-only: compares the GitHub "About" count to registry.json. The
+        # default token can read repo metadata but not write it, so a stale
+        # count is reported here and fixed with `cli-web-devkit about --apply`
+        # (a maintainer step). No-ops if gh metadata is unavailable.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: PYTHONPATH=devkit python -m cli_web_devkit about --check
 
   plugin:
     name: plugin & devkit tests

--- a/cli-anything-web-plugin/skills/standards/SKILL.md
+++ b/cli-anything-web-plugin/skills/standards/SKILL.md
@@ -263,6 +263,7 @@ entry, then run the generators — never edit those outputs by hand:
 # 1. Add the entry to registry.json (schema below), then:
 cli-web-devkit registry validate     # entry <-> fleet cross-check
 cli-web-devkit docs                  # regenerates README table + install block
+cli-web-devkit about --apply         # syncs the GitHub "About" CLI count (needs gh admin)
 cli-web-devkit resync --app <app>    # vendored files in sync + manifest updated
 cli-web-devkit drift                 # must report 0 drifted/missing
 

--- a/devkit/cli_web_devkit/about.py
+++ b/devkit/cli_web_devkit/about.py
@@ -43,7 +43,7 @@ def desired_description(description: str, count: int) -> str:
     return f"{description.rstrip().rstrip('.')}. {count} CLIs and counting."
 
 
-def _gh(*args: str) -> subprocess.CompletedProcess:
+def _gh(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
 
 

--- a/devkit/cli_web_devkit/about.py
+++ b/devkit/cli_web_devkit/about.py
@@ -1,0 +1,64 @@
+"""Keep the GitHub repo "About" description's CLI count in sync with the fleet.
+
+The repo description embeds a count — ``... N CLIs and counting.`` — that must
+match the number of CLIs in registry.json. GitHub repo metadata is not a file,
+so this is enforced through the GitHub API (the ``gh`` CLI), not the README
+marker mechanism used by ``docs``:
+
+- ``about --check`` compares the count in the live description to the registry
+  and fails on drift. Read-only — runs with the default Actions token.
+- ``about --apply`` rewrites just the count in the live description, preserving
+  the surrounding prose. Editing repo metadata needs a token with
+  ``Administration: write`` — the default ``GITHUB_TOKEN`` cannot, so this is a
+  local step (your ``gh`` login) or a PAT-backed CI job.
+
+Only the count is templated; the prose is whatever the maintainer set, so a
+reworded tagline survives ``--apply``.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+from .registry import Registry
+
+# Match the count token in the description, e.g. "19 CLIs".
+_COUNT_RE = re.compile(r"\b\d+\s+CLIs\b")
+
+
+def fleet_count(root: Path) -> int:
+    """Number of CLIs in the fleet — the single source of truth."""
+    return len(Registry.load(root / "registry.json").clis)
+
+
+def desired_description(description: str, count: int) -> str:
+    """Return ``description`` with its ``<n> CLIs`` count set to ``count``.
+
+    If the description has no count token, append the standard suffix.
+    """
+    if _COUNT_RE.search(description):
+        return _COUNT_RE.sub(f"{count} CLIs", description, count=1)
+    return f"{description.rstrip().rstrip('.')}. {count} CLIs and counting."
+
+
+def _gh(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+
+
+def live_description() -> str:
+    """Fetch the repo's current GitHub description via ``gh``."""
+    proc = _gh("repo", "view", "--json", "description", "-q", ".description")
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh repo view failed ({proc.returncode}): {proc.stderr.strip() or 'is gh installed and authenticated?'}"
+        )
+    return proc.stdout.strip()
+
+
+def apply_description(description: str) -> None:
+    """Set the repo's GitHub description (needs Administration: write)."""
+    proc = _gh("repo", "edit", "--description", description)
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh repo edit failed ({proc.returncode}): {proc.stderr.strip()}")

--- a/devkit/cli_web_devkit/cli.py
+++ b/devkit/cli_web_devkit/cli.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from .about import apply_description, desired_description, fleet_count, live_description
 from .canary import run_canaries
 from .docs import generate as generate_docs
 from .gaps import analyze as analyze_gaps
@@ -44,6 +45,35 @@ def _cmd_docs(args: argparse.Namespace) -> int:
         )
         return 1
     print("README.md regenerated" if not fresh else "README.md already up to date")
+    return 0
+
+
+def _cmd_about(args: argparse.Namespace) -> int:
+    count = fleet_count(args.root)
+    try:
+        live = live_description()
+    except RuntimeError as exc:
+        # No gh / not authenticated. Don't fail CI for a metadata nicety;
+        # report and move on (the count is enforced when gh is available).
+        print(f"about: skipped — {exc}", file=sys.stderr)
+        return 0
+    desired = desired_description(live, count)
+    if live == desired:
+        print(f"About description in sync ({count} CLIs)")
+        return 0
+    if args.apply:
+        apply_description(desired)
+        print(f"About description updated -> {count} CLIs")
+        return 0
+    if args.check:
+        print(
+            f"About description STALE (fleet has {count} CLIs) — run: cli-web-devkit about --apply",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"current: {live}")
+    print(f"desired: {desired}")
+    print("run: cli-web-devkit about --apply")
     return 0
 
 
@@ -149,6 +179,15 @@ def main(argv: list[str] | None = None) -> int:
     p_docs = sub.add_parser("docs", help="Regenerate README fleet sections from registry.json")
     p_docs.add_argument("--check", action="store_true", help="Fail if README is stale")
     p_docs.set_defaults(func=_cmd_docs)
+
+    p_about = sub.add_parser(
+        "about", help="Sync the GitHub repo description's CLI count with registry.json"
+    )
+    p_about.add_argument("--check", action="store_true", help="Fail if the count is stale (CI)")
+    p_about.add_argument(
+        "--apply", action="store_true", help="Update the live description (needs gh admin)"
+    )
+    p_about.set_defaults(func=_cmd_about)
 
     p_gaps = sub.add_parser("gaps", help="Captured-vs-implemented-vs-exposed gap report")
     p_gaps.add_argument("app", help="App directory name (e.g. hackernews)")

--- a/devkit/tests/test_about.py
+++ b/devkit/tests/test_about.py
@@ -1,0 +1,58 @@
+import json
+
+from cli_web_devkit.about import desired_description, fleet_count
+
+
+def test_desired_description_replaces_count():
+    desc = "Claude Code plugin that generates CLIs for any web app. 17 CLIs and counting."
+    assert (
+        desired_description(desc, 19)
+        == "Claude Code plugin that generates CLIs for any web app. 19 CLIs and counting."
+    )
+
+
+def test_desired_description_is_idempotent():
+    desc = "Generates CLIs. 19 CLIs and counting."
+    assert desired_description(desc, 19) == desc
+
+
+def test_desired_description_preserves_reworded_prose():
+    # Only the count is templated — a hand-edited tagline survives.
+    desc = "A totally different tagline — 3 CLIs and counting, more soon!"
+    assert (
+        desired_description(desc, 19)
+        == "A totally different tagline — 19 CLIs and counting, more soon!"
+    )
+
+
+def test_desired_description_appends_when_no_count():
+    desc = "Claude Code plugin that generates CLIs for any web app."
+    assert desired_description(desc, 19) == (
+        "Claude Code plugin that generates CLIs for any web app. 19 CLIs and counting."
+    )
+
+
+def test_desired_description_only_replaces_first_count():
+    desc = "5 CLIs now, was 2 CLIs before."
+    assert desired_description(desc, 19) == "19 CLIs now, was 2 CLIs before."
+
+
+def test_fleet_count_matches_registry(tmp_path):
+    registry = {
+        "version": "1.0.0",
+        "clis": [
+            {
+                "name": f"cli-web-app{i}",
+                "website": "example.com",
+                "protocol": "REST",
+                "auth": "none",
+                "directory": f"app{i}/agent-harness",
+                "namespace": f"cli_web.app{i}",
+                "commands": ["things list"],
+                "install": f"pip install -e app{i}/agent-harness",
+            }
+            for i in range(7)
+        ],
+    }
+    (tmp_path / "registry.json").write_text(json.dumps(registry))
+    assert fleet_count(tmp_path) == 7


### PR DESCRIPTION
## What this does

The repo "About" description embeds a CLI count (`… N CLIs and counting.`) that was hand-maintained and had drifted — it said **17** while `registry.json` has **19**. This makes the count derive from the registry (the fleet source of truth) and keeps it honest.

- **`cli-web-devkit about`** — renders the count from `registry.json` and reconciles it with the live GitHub description via the `gh` API. `--check` fails on drift (read-only, CI-safe); `--apply` rewrites *only* the count, preserving any reworded prose.
- **CI guardrail** — `tests.yml` lint job runs `about --check`; no-ops if `gh` metadata is unavailable so it never flakes.
- **Auto-apply (opt-in)** — `about-sync.yml` runs `about --apply` on pushes to `main` that touch `registry.json`. Editing repo metadata needs `Administration: write`, which the default `GITHUB_TOKEN` can't have, so it uses a maintainer PAT in the `REPO_ADMIN_TOKEN` secret. **Until that secret exists the job no-ops** — the `--check` guardrail covers the gap.
- **Registration flow** — standards Step 6 runs `about --apply` alongside the other registry-driven generators.
- The live description is already corrected to **19**.

## Verification

- 708 unit tests pass (6 new); ruff lint + format clean; `cli-web-devkit drift` → 60 ok / 0; `about --check` reports in sync against the live repo.
