### PR TITLE
fix(worldcup): populate match venue and drop empty-provider odds colon

### DIFF
--- a/worldcup/agent-harness/cli_web/worldcup/core/models.py
+++ b/worldcup/agent-harness/cli_web/worldcup/core/models.py
@@ -43,7 +43,14 @@ class Match:
                 away, away_score = name, score
         notes = comp.get("notes") or []
         stage = notes[0].get("headline", "") if notes else ""
-        venue = (ev.get("venue") or comp.get("venue") or {}).get("fullName", "")
+        # The competition-level venue carries `fullName`; the event-level one
+        # only has `displayName` — so prefer the competition venue and fall
+        # back to the event's display name.
+        venue = (
+            (comp.get("venue") or {}).get("fullName")
+            or (ev.get("venue") or {}).get("displayName")
+            or ""
+        )
         return cls(
             id=str(ev.get("id", "")),
             date=ev.get("date", ""),
@@ -75,7 +82,10 @@ def _odds_line(odds: list) -> str:
         bits.append(str(o["details"]))
     if o.get("overUnder") is not None:
         bits.append(f"O/U {o['overUnder']}")
-    return f"{provider}: {' '.join(bits)}".strip().rstrip(":") if bits else provider
+    detail = " ".join(bits)
+    if provider and detail:
+        return f"{provider}: {detail}"
+    return provider or detail
 
 
 @dataclass

--- a/worldcup/agent-harness/cli_web/worldcup/tests/test_core.py
+++ b/worldcup/agent-harness/cli_web/worldcup/tests/test_core.py
@@ -51,6 +51,37 @@ def test_match_odds_line_from_espn():
     assert "DraftKings" in m.odds or m.odds == ""
 
 
+def test_match_venue_prefers_competition_full_name():
+    # Event-level venue has only displayName; competition-level has fullName.
+    ev = {
+        "id": "1",
+        "venue": {"displayName": "Short Name"},
+        "competitions": [
+            {
+                "competitors": [],
+                "venue": {"fullName": "Estadio Banorte"},
+            }
+        ],
+    }
+    assert Match.from_event(ev).venue == "Estadio Banorte"
+
+
+def test_match_venue_falls_back_to_event_display_name():
+    ev = {"id": "1", "venue": {"displayName": "Estadio Akron"}, "competitions": [{}]}
+    assert Match.from_event(ev).venue == "Estadio Akron"
+
+
+def test_odds_line_omits_empty_provider_colon():
+    from cli_web.worldcup.core.models import _odds_line
+
+    # Provider missing → no leading ": " (the bug fixed here).
+    line = _odds_line([{"details": "KOR +170", "overUnder": 2.5}])
+    assert line == "KOR +170 O/U 2.5"
+    # Provider present → "Provider: ...".
+    line = _odds_line([{"provider": {"displayName": "DraftKings"}, "details": "MEX -250"}])
+    assert line == "DraftKings: MEX -250"
+
+
 def test_team_from_team():
     teams = _fix("teams.json")["sports"][0]["leagues"][0]["teams"]
     t = Team.from_team(teams[0]["team"])


### PR DESCRIPTION
Two data-quality bugs the `--json` output verification surfaced on `fixtures list` (the project's "empty fields = incomplete parser" rule):

- **venue was always empty** — ESPN's event-level `venue` carries only `displayName`, while the competition-level one has `fullName`. The parser took the event venue first (truthy, but no `fullName`), so `.get("fullName")` returned empty. Now prefers competition `fullName`, falls back to event `displayName` (e.g. `Estadio Banorte`).
- **odds line had a leading colon** — `": KOR +170 O/U 2.5"` when the bookmaker/provider name was absent. The line now drops the colon when there's no provider.

Verified live: the opener now shows `venue: "Estadio Banorte"`, `odds: "DraftKings: MEX -240 O/U 2.5"`; the second match `venue: "Estadio Akron"`, `odds: "KOR +170 O/U 2.5"`. Adds 3 regression tests (venue precedence + fallback, odds line with/without provider). 39 worldcup tests pass; ruff clean.

Read-only odds data — no betting.