### PR TITLE
chore(publish): make cli-web-reddit the next package to publish

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -61,6 +61,14 @@
       "bump-minor-pre-major": true,
       "include-component-in-tag": true
     },
+    "reddit/agent-harness": {
+      "release-type": "python",
+      "component": "cli-web-reddit",
+      "package-name": "cli-web-reddit",
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": true,
+      "release-as": "0.1.1"
+    },
     "futbin/agent-harness": {
       "release-type": "python",
       "component": "cli-web-futbin",
@@ -121,14 +129,6 @@
       "release-type": "python",
       "component": "cli-web-pexels",
       "package-name": "cli-web-pexels",
-      "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
-    },
-    "reddit/agent-harness": {
-      "release-type": "python",
-      "component": "cli-web-reddit",
-      "package-name": "cli-web-reddit",
       "bump-minor-pre-major": true,
       "include-component-in-tag": true,
       "release-as": "0.1.1"


### PR DESCRIPTION
## What

Moves `reddit/agent-harness` to the **first CLI slot** in `release-please-config.json`. Pure reordering — no version bumps, no metadata changes.

## Why

`publish-backfill.yml` iterates `release-please-config.json` in order and, for each not-yet-published package, attempts a `twine upload`. A package only lands when PyPI's *time-based* new-project-creation throttle happens to allow a creation at the moment of its attempt — which is why later-in-config packages (codewiki, hackernews) published before earlier ones (stitch, pexels).

Putting reddit first means it gets the **first, freshest upload attempt of every run** (most budget available, nothing consumed yet that run) — the strongest lever to make it the next of the remaining pending packages to go live.

Remaining pending before this change: `gai`, `pexels`, `reddit`, `stitch`, `youtube`. After merge, reddit is attempted first each run.

## Caveat

This maximizes reddit's odds but isn't a hard 100% guarantee — if reddit's first attempt 429s and a later package's attempt catches an open throttle window, that one could still win. First position is the best available lever, though.

## To take effect

Merge to `main` (the scheduled backfill runs from the default branch), then either wait for the next 4-hour cron or dispatch **Actions → "Publish backfill (every 4h)" → Run workflow → main**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wCNXuLy6UpGJ1jcPdsD5i

---
_Generated by [Claude Code](https://claude.ai/code/session_017wCNXuLy6UpGJ1jcPdsD5i)_