### PR TITLE
Fix Reddit read commands: route through OAuth API

### DIFF
--- a/reddit/agent-harness/cli_web/reddit/core/client.py
+++ b/reddit/agent-harness/cli_web/reddit/core/client.py
@@ -48,7 +48,27 @@ class RedditClient:
 
     # ── HTTP helpers ────────────────────────────────────────────
 
+    @staticmethod
+    def _to_oauth_path(path: str) -> str:
+        """Map a public ``.json`` path to its oauth.reddit.com equivalent.
+
+        The OAuth API serves the same endpoints without the ``.json`` suffix
+        and returns JSON natively: ``/r/x/about.json`` -> ``/r/x/about``,
+        ``/hot/.json`` -> ``/hot``.
+        """
+        if path.endswith("/.json"):
+            return path[: -len("/.json")]
+        if path.endswith(".json"):
+            return path[: -len(".json")]
+        return path
+
     def _get(self, path: str, params: dict | None = None) -> dict | list:
+        # Reddit now 403s the public www.reddit.com/.json API for non-OAuth
+        # clients. When we have a bearer token, read through oauth.reddit.com
+        # (same endpoints, minus the .json suffix); fall back to the public
+        # path only when logged out.
+        if get_bearer_token():
+            return self._oauth_get(self._to_oauth_path(path), params=params)
         url = f"{BASE_URL}{path}"
         try:
             resp = self._session.get(url, params=params)

--- a/reddit/agent-harness/cli_web/reddit/tests/test_core.py
+++ b/reddit/agent-harness/cli_web/reddit/tests/test_core.py
@@ -290,6 +290,35 @@ class TestClient:
         data = client.feed_hot(limit=3)
         assert data["data"]["children"][0]["kind"] == "t3"
 
+    def test_to_oauth_path_strips_json_suffix(self):
+        from cli_web.reddit.core.client import RedditClient
+
+        assert RedditClient._to_oauth_path("/r/x/about.json") == "/r/x/about"
+        assert RedditClient._to_oauth_path("/r/x/about/rules.json") == "/r/x/about/rules"
+        assert RedditClient._to_oauth_path("/hot/.json") == "/hot"
+        assert RedditClient._to_oauth_path("/r/x/search.json") == "/r/x/search"
+        assert RedditClient._to_oauth_path("/api/v1/me") == "/api/v1/me"
+
+    @patch("cli_web.reddit.core.client.curl_requests.Session")
+    @patch("cli_web.reddit.core.client.get_bearer_token", return_value="tok123")
+    def test_reads_route_through_oauth_when_authed(self, mock_token, MockSession):
+        """With a bearer token, reads hit oauth.reddit.com (not the public
+        .json API, which Reddit now 403s) and carry the Authorization header."""
+        from cli_web.reddit.core.client import OAUTH_URL, RedditClient
+
+        session = MagicMock()
+        MockSession.return_value = session
+        session.get.return_value = _mock_response(json_data=SAMPLE_LISTING)
+
+        client = RedditClient()
+        client.feed_hot(limit=3)
+
+        oauth_calls = [c for c in session.get.call_args_list if "oauth.reddit.com" in c.args[0]]
+        assert oauth_calls, "authenticated read should go through oauth.reddit.com"
+        last = oauth_calls[-1]
+        assert last.args[0] == f"{OAUTH_URL}/hot"  # .json suffix stripped for OAuth
+        assert last.kwargs["headers"]["Authorization"] == "Bearer tok123"
+
     @patch("cli_web.reddit.core.client.curl_requests.Session")
     @patch("cli_web.reddit.core.client.get_bearer_token", return_value=None)
     def test_404_raises_not_found(self, mock_token, MockSession):

--- a/reddit/agent-harness/setup.py
+++ b/reddit/agent-harness/setup.py
@@ -16,10 +16,11 @@ setup(
         "curl_cffi",
         "rich>=13.0",
         "prompt_toolkit>=3.0",
+        # Required: auth login (and silent token refresh) drive a real browser
+        # via playwright, and Reddit now 403s anonymous reads, so a logged-in
+        # session is needed for every command.
+        "playwright>=1.40.0",
     ],
-    extras_require={
-        "browser": ["playwright>=1.40.0"],
-    },
     entry_points={
         "console_scripts": [
             "cli-web-reddit=cli_web.reddit.reddit_cli:main",


### PR DESCRIPTION
## Problem

Every read command in `cli-web-reddit` (`sub`, `feed`, `search`, `user`, `post`) failed with `Access denied. Token may have expired.` — **even with a valid login**. Only `me` / `auth status` worked.

## Root cause

Reddit now returns **403** for the unauthenticated public `www.reddit.com/.json` API. The read path (`_get`/`_get_listing`) hit that public API with **no token at all** — only `_oauth_*` (used by `me`) sent the bearer. Verified directly:

- `www.reddit.com/r/opensource/about.json` (no auth) → **403**
- same + Bearer header → **403** (www host ignores Bearer)
- `oauth.reddit.com/r/opensource/about` + Bearer → **200** ✅

## Fix

- `core/client.py`: `_get` now routes through `oauth.reddit.com` with the bearer token when logged in (a single change point — `_get_listing` delegates to `_get`, so all readers are covered). Falls back to the public `.json` path when logged out. Added `_to_oauth_path` to strip the `.json` suffix the OAuth API doesn't use.
- `setup.py`: promote `playwright` from an optional `[browser]` extra to a core dependency — `auth login` (and, now that anonymous reads 403, every command) needs it. Fixes the first-run `ModuleNotFoundError: No module named 'playwright'`.

## Tests

- Added `test_to_oauth_path_strips_json_suffix` and `test_reads_route_through_oauth_when_authed`.
- Full unit suite green: **46 passed**.
- Verified end-to-end against live Reddit: `sub info`, `sub rules`, `feed popular`, `sub hot` all return data.