### PR TITLE
fix(reddit): route reads through OAuth API and clarify auth-required error

### DIFF
--- a/reddit/agent-harness/cli_web/reddit/core/client.py
+++ b/reddit/agent-harness/cli_web/reddit/core/client.py
@@ -83,7 +83,8 @@ class RedditClient:
             )
         if resp.status_code == 403:
             raise AuthError(
-                "Access denied. Token may have expired. Run: cli-web-reddit auth login",
+                "Access denied. Reddit requires a logged-in session for reads "
+                "(the anonymous API is blocked). Run: cli-web-reddit auth login",
                 recoverable=True,
             )
         if resp.status_code == 404:


### PR DESCRIPTION
Reddit now 403s the anonymous www.reddit.com/.json API, so reads require a logged-in session. The OAuth read routing for all read commands landed earlier (#44) but was merged with a non-conventional commit, so release-please did not cut a reddit release. This conventional commit carries that fix into a release and also clarifies the 403 error message to say login is required rather than implying token expiry.