### PR TITLE
chore: retire release-as backfill directives

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -66,168 +66,147 @@
       "component": "cli-web-reddit",
       "package-name": "cli-web-reddit",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "futbin/agent-harness": {
       "release-type": "python",
       "component": "cli-web-futbin",
       "package-name": "cli-web-futbin",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "notebooklm/agent-harness": {
       "release-type": "python",
       "component": "cli-web-notebooklm",
       "package-name": "cli-web-notebooklm",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "gh-trending/agent-harness": {
       "release-type": "python",
       "component": "cli-web-gh-trending",
       "package-name": "cli-web-gh-trending",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "producthunt/agent-harness": {
       "release-type": "python",
       "component": "cli-web-producthunt",
       "package-name": "cli-web-producthunt",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "unsplash/agent-harness": {
       "release-type": "python",
       "component": "cli-web-unsplash",
       "package-name": "cli-web-unsplash",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "booking/agent-harness": {
       "release-type": "python",
       "component": "cli-web-booking",
       "package-name": "cli-web-booking",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "stitch/agent-harness": {
       "release-type": "python",
       "component": "cli-web-stitch",
       "package-name": "cli-web-stitch",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "pexels/agent-harness": {
       "release-type": "python",
       "component": "cli-web-pexels",
       "package-name": "cli-web-pexels",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "gai/agent-harness": {
       "release-type": "python",
       "component": "cli-web-gai",
       "package-name": "cli-web-gai",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "youtube/agent-harness": {
       "release-type": "python",
       "component": "cli-web-youtube",
       "package-name": "cli-web-youtube",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "hackernews/agent-harness": {
       "release-type": "python",
       "component": "cli-web-hackernews",
       "package-name": "cli-web-hackernews",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "codewiki/agent-harness": {
       "release-type": "python",
       "component": "cli-web-codewiki",
       "package-name": "cli-web-codewiki",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "chatgpt/agent-harness": {
       "release-type": "python",
       "component": "cli-web-chatgpt",
       "package-name": "cli-web-chatgpt",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "airbnb/agent-harness": {
       "release-type": "python",
       "component": "cli-web-airbnb",
       "package-name": "cli-web-airbnb",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "amazon/agent-harness": {
       "release-type": "python",
       "component": "cli-web-amazon",
       "package-name": "cli-web-amazon",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "tripadvisor/agent-harness": {
       "release-type": "python",
       "component": "cli-web-tripadvisor",
       "package-name": "cli-web-tripadvisor",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "linkedin/agent-harness": {
       "release-type": "python",
       "component": "cli-web-linkedin",
       "package-name": "cli-web-linkedin",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "capitoltrades/agent-harness": {
       "release-type": "python",
       "component": "cli-web-capitoltrades",
       "package-name": "cli-web-capitoltrades",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "worldcup/agent-harness": {
       "release-type": "python",
       "component": "cli-web-worldcup",
       "package-name": "cli-web-worldcup",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     },
     "meta": {
       "release-type": "python",
       "component": "cli-anything-web-meta",
       "package-name": "cli-anything-web",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "0.1.1"
+      "include-component-in-tag": true
     }
   }
 }


### PR DESCRIPTION
release-as: 0.1.1 was pinned on 21 packages. The 7 already-released ones caused duplicate-tag failures that broke every release run (#43, and would break #46). Removing all release-as makes releases conventional-commit driven again. cli-web-reddit still releases via its fix(reddit) commit (#45).