### PR TITLE
fix: harden fleet maintenance and live read commands

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: pip
+    directories:
+      - /
+      - /airbnb/agent-harness
+      - /amazon/agent-harness
+      - /booking/agent-harness
+      - /capitoltrades/agent-harness
+      - /chatgpt/agent-harness
+      - /cli-web-core
+      - /codewiki/agent-harness
+      - /devkit
+      - /futbin/agent-harness
+      - /gai/agent-harness
+      - /gh-trending/agent-harness
+      - /hackernews/agent-harness
+      - /linkedin/agent-harness
+      - /meta
+      - /notebooklm/agent-harness
+      - /pexels/agent-harness
+      - /producthunt/agent-harness
+      - /reddit/agent-harness
+      - /stitch/agent-harness
+      - /tripadvisor/agent-harness
+      - /unsplash/agent-harness
+      - /worldcup/agent-harness
+      - /youtube/agent-harness
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      fleet-python-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - dependencies
+      - python
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+      - tooling

--- a/.github/workflows/about-sync.yml
+++ b/.github/workflows/about-sync.yml
@@ -21,8 +21,8 @@ jobs:
     name: sync About CLI count
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Apply About description from registry.json

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -17,8 +17,8 @@ jobs:
   canary:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -37,6 +37,32 @@ jobs:
                   )
           EOF
 
+      # Unsplash and FUTBIN use Camoufox to clear browser challenges.
+      # Installing the Python package does not install its browser payload, so
+      # an uncached canary otherwise emits download progress and exits before
+      # it can return JSON.
+      - name: Restore Camoufox browser
+        id: camoufox-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/camoufox
+          key: camoufox-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('unsplash/agent-harness/setup.py', 'futbin/agent-harness/setup.py') }}
+
+      - name: Install Camoufox browser
+        if: steps.camoufox-cache.outputs.cache-hit != 'true'
+        run: python -m camoufox fetch
+
+      - name: Restore Playwright Chromium
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('gai/agent-harness/setup.py') }}
+
+      - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: python -m playwright install chromium
+
       - name: Run canaries
         id: canary
         run: |
@@ -47,7 +73,7 @@ jobs:
 
       - name: Open or update breakage issue
         if: steps.canary.outputs.exit_code != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -100,6 +126,33 @@ jobs:
                 title,
                 body,
                 labels: ['site-breakage'],
+              });
+            }
+
+      - name: Close recovered breakage issue
+        if: steps.canary.outputs.exit_code == '0'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'site-breakage',
+            });
+            for (const issue of issues) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'All actionable fleet canaries recovered. Closing automatically.',
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
               });
             }
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: analyze Python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: python
+          queries: security-extended
+      - name: Analyze
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: /language:python

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -14,8 +14,8 @@ jobs:
   contract:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -26,6 +26,26 @@ jobs:
 
       - name: Vendored shared-file drift check
         run: cli-web-devkit drift
+
+      - name: Strict fleet checklist
+        run: |
+          python - <<'PY'
+          import json
+          import subprocess
+
+          for cli in json.load(open("registry.json"))["clis"]:
+              subprocess.run(
+                  [
+                      "python",
+                      "cli-anything-web-plugin/scripts/validate-checklist.py",
+                      cli["directory"],
+                      "--app-name",
+                      cli["name"].removeprefix("cli-web-"),
+                      "--strict",
+                  ],
+                  check=True,
+              )
+          PY
 
       - name: Fleet contract suite
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,10 +35,10 @@ jobs:
         id: tag
         run: echo "tag=${{ github.event.release.tag_name || github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.tag.outputs.tag }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -63,7 +63,7 @@ jobs:
           python -m build "${{ steps.pkg.outputs.dir }}" --outdir dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
       pr_branch: ${{ steps.rp.outputs.prs_created == 'true' && 'release-please--branches--main' || '' }}
     steps:
       - id: rp
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         # Manifest mode: packages, changelog sections, and extra-files live
         # in release-please-config.json / .release-please-manifest.json.
         #

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,5 +110,40 @@ jobs:
         run: |
           test_file="${{ matrix.cli.dir }}/cli_web/${{ matrix.cli.pkg }}/tests/test_e2e.py"
           if [ -f "$test_file" ]; then
-            python -m pytest "$test_file" -k "help or version" -v
+            smoke_tests="$(
+              python - "$test_file" <<'PY'
+          import ast
+          import sys
+          from pathlib import Path
+
+          path = Path(sys.argv[1])
+          smoke_names = {
+              "test_help",
+              "test_help_loads",
+              "test_help_output",
+              "test_cli_help",
+              "test_version",
+              "test_cli_version",
+              "test_version_works",
+          }
+          for node in ast.parse(path.read_text(encoding="utf-8")).body:
+              if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                  if node.name in smoke_names:
+                      print(f"{path}::{node.name}")
+              elif isinstance(node, ast.ClassDef):
+                  for function in node.body:
+                      if (
+                          isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef))
+                          and function.name in smoke_names
+                      ):
+                          print(f"{path}::{node.name}::{function.name}")
+          PY
+            )"
+            if [ -z "$smoke_tests" ]; then
+              echo "No exact help/version subprocess tests found in $test_file" >&2
+              exit 1
+            fi
+            # Node IDs cannot contain spaces in this fleet, so intentional
+            # word splitting passes each collected smoke test separately.
+            python -m pytest -o addopts= $smoke_tests -v
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,14 +17,14 @@ jobs:
     name: lint & registry
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Install ruff
-        run: pip install ruff==0.15.8
+        run: pip install ruff==0.16.3
       - name: Ruff lint
         run: ruff check .
       - name: Ruff format check
@@ -46,10 +46,10 @@ jobs:
     name: plugin & devkit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Install test tooling
@@ -70,10 +70,10 @@ jobs:
     outputs:
       clis: ${{ steps.set.outputs.clis }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Generate matrix from registry.json
@@ -91,10 +91,10 @@ jobs:
         python: ["3.10", "3.12"]
         cli: ${{ fromJSON(needs.matrix.outputs.clis) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python }}
       - name: Install CLI package
@@ -103,3 +103,12 @@ jobs:
         run: pip install pytest
       - name: Run unit tests
         run: python -m pytest ${{ matrix.cli.dir }}/cli_web/${{ matrix.cli.pkg }}/tests/test_core.py -v
+      - name: Run offline subprocess E2E tests
+        if: matrix.python == '3.12'
+        env:
+          CLI_WEB_FORCE_INSTALLED: "1"
+        run: |
+          test_file="${{ matrix.cli.dir }}/cli_web/${{ matrix.cli.pkg }}/tests/test_e2e.py"
+          if [ -f "$test_file" ]; then
+            python -m pytest "$test_file" -k "help or version" -v
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -13,7 +13,7 @@ repos:
         exclude: ^assets/
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.16.3
     hooks:
       - id: ruff-check
         args: ["--fix"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+* enforce structured JSON envelopes, parse errors, and canonical auth exit codes across the fleet
+* verify browser payloads in `doctor` instead of reporting false-green GAI, Unsplash, and FUTBIN setups
+* restore live FUTBIN and World Cup reads with browser-compatible transports
+* bound and complete NotebookLM, Reddit, and Stitch authentication refresh flows
+* expose captured Hacker News, Pexels, Stitch, Unsplash, and World Cup read endpoints
+* repair LinkedIn company routing and Pexels search-to-detail slug round trips
+* improve Product Hunt post extraction and remove its non-functional period option
+* prevent GAI from returning successful empty answers and classify CAPTCHA blocks explicitly
+* bootstrap and cache Camoufox before the Unsplash live canary
+* add browser-aware canaries, strict fleet validation, subprocess E2E checks, and an enforced coverage floor
+* register the fleet's `unit` pytest marker and refresh maintenance tooling
+* correct the plugin repository metadata and publishing instructions
+
+### Security
+
+* pin third-party GitHub Actions to reviewed immutable revisions
+* add Dependabot coverage for Actions, pre-commit, and every Python package
+* add weekly CodeQL analysis using the security-extended query suite
+
 ## [0.14.1](https://github.com/ItamarZand88/CLI-Anything-WEB/compare/v0.14.0...v0.14.1) (2026-06-21)
 
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@
   <a href="https://github.com/ItamarZand88/CLI-Anything-WEB/stargazers"><img src="https://img.shields.io/github/stars/ItamarZand88/CLI-Anything-WEB?style=social" alt="GitHub Stars"></a>
   <a href="https://github.com/ItamarZand88/CLI-Anything-WEB/issues"><img src="https://img.shields.io/github/issues/ItamarZand88/CLI-Anything-WEB" alt="Issues"></a>
   <img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+">
-  <img src="https://img.shields.io/badge/CLIs_generated-19-brightgreen" alt="19 CLIs">
+  <img src="https://img.shields.io/badge/CLIs_generated-20-brightgreen" alt="20 CLIs">
   <img src="https://img.shields.io/badge/claude%20code-plugin-blueviolet" alt="Claude Code Plugin">
   <a href="https://itamarzand88.github.io/CLI-Anything-WEB/registry/"><img src="https://img.shields.io/badge/registry-live-orange" alt="CLI Registry"></a>
 </p>
 
 <p align="center">
   <a href="#-quick-start"><img src="https://img.shields.io/badge/Quick_Start-blue?style=for-the-badge" alt="Quick Start"></a>
-  <a href="#-examples"><img src="https://img.shields.io/badge/19_CLIs-brightgreen?style=for-the-badge" alt="Examples"></a>
+  <a href="#-examples"><img src="https://img.shields.io/badge/20_CLIs-brightgreen?style=for-the-badge" alt="Examples"></a>
   <a href="#-supported-protocols"><img src="https://img.shields.io/badge/7_Protocols-orange?style=for-the-badge" alt="Protocols"></a>
   <a href="#-contributing"><img src="https://img.shields.io/badge/Contributing-purple?style=for-the-badge" alt="Contributing"></a>
 </p>
@@ -103,7 +103,7 @@ The agent opens a browser, asks you to log in if needed, captures traffic, and g
 | [`cli-web-booking`](booking/) | Booking.com | GraphQL + HTML (curl_cffi) | WAF cookies | [📖 Skill](.claude/skills/booking-cli/SKILL.md) | Hotel search, property details, destination resolution |
 | [`cli-web-stitch`](stitch/) | Google Stitch | batchexecute RPC | Google SSO | [📖 Skill](.claude/skills/stitch-cli/SKILL.md) | AI UI design — generate mobile/web app mockups from text prompts |
 | [`cli-web-pexels`](pexels/) | Pexels | SSR + __NEXT_DATA__ (curl_cffi) | None | [📖 Skill](.claude/skills/pexels-cli/SKILL.md) | Free stock photos & videos — search, download, collections, profiles |
-| [`cli-web-reddit`](reddit/) | Reddit | REST JSON API (curl_cffi) | Optional (OAuth) | [📖 Skill](.claude/skills/reddit-cli/SKILL.md) | Feeds, subreddits, search, vote, comment, submit, save, inbox |
+| [`cli-web-reddit`](reddit/) | Reddit | REST JSON API (curl_cffi) | Required (OAuth via token_v2) | [📖 Skill](.claude/skills/reddit-cli/SKILL.md) | Feeds, subreddits, search, vote, comment, submit, save, inbox |
 | [`cli-web-gai`](gai/) | Google AI Mode | Browser-rendered (Playwright) | None | [📖 Skill](.claude/skills/gai-cli/SKILL.md) | AI-powered search with source references |
 | [`cli-web-youtube`](youtube/) | YouTube | InnerTube REST API (httpx) | None | [📖 Skill](.claude/skills/youtube-cli/SKILL.md) | Search videos, video details, trending, channel info |
 | [`cli-web-hackernews`](hackernews/) | Hacker News | REST API — Firebase + Algolia (httpx) | Cookie (optional) | [📖 Skill](.claude/skills/hackernews-cli/SKILL.md) | Stories, search, comments, users, upvote, submit, comment, favorite |
@@ -192,7 +192,7 @@ cli-web-pexels photos search "mountains" --json
 **Reddit** — feeds, search, vote, comment, submit
 ```bash
 pip install cli-web-reddit
-cli-web-reddit auth login         # optional — required for voting, commenting, submitting
+cli-web-reddit auth login         # required by Reddit for all current API reads
 cli-web-reddit feed hot --limit 5 --json
 ```
 
@@ -284,6 +284,20 @@ cli-web-capitoltrades --json politicians top --by trades --page-size 10
 
 # Rich issuer data with 1-year price history
 cli-web-capitoltrades --json issuers search nvidia
+```
+
+**YouTube** — videos, channels, trending, and transcripts (no auth)
+```bash
+pip install cli-web-youtube
+cli-web-youtube search videos "python tutorial" --limit 5 --json
+cli-web-youtube transcript get dQw4w9WgXcQ --json
+```
+
+**World Cup 2026** — fixtures, teams, rosters, and standings (no auth)
+```bash
+pip install cli-web-worldcup
+cli-web-worldcup fixtures list --limit 5 --json
+cli-web-worldcup teams list --json
 ```
 
 ### Agent-Native: Claude uses the CLIs automatically

--- a/airbnb/agent-harness/.manifest.json
+++ b/airbnb/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/airbnb/agent-harness/.manifest.json
+++ b/airbnb/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/airbnb/agent-harness/.manifest.json
+++ b/airbnb/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/airbnb/agent-harness/cli_web/airbnb/airbnb_cli.py
+++ b/airbnb/agent-harness/cli_web/airbnb/airbnb_cli.py
@@ -24,12 +24,13 @@ from .commands.autocomplete import autocomplete_group
 from .commands.listings import listings
 from .commands.search import search
 from .core.exceptions import AirbnbError
+from .utils.json_group import JsonGroup
 from .utils.repl_skin import ReplSkin
 
 _skin = ReplSkin("airbnb", version="0.1.0")
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, help="Output all results as JSON.")
 @click.option("--version", is_flag=True, help="Show version and exit.")
 @click.pass_context

--- a/airbnb/agent-harness/cli_web/airbnb/utils/doctor.py
+++ b/airbnb/agent-harness/cli_web/airbnb/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/airbnb/agent-harness/cli_web/airbnb/utils/doctor.py
+++ b/airbnb/agent-harness/cli_web/airbnb/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/airbnb/agent-harness/cli_web/airbnb/utils/helpers.py
+++ b/airbnb/agent-harness/cli_web/airbnb/utils/helpers.py
@@ -97,7 +97,12 @@ def resolve_json_mode(json_mode: bool, ctx: click.Context | None = None) -> bool
 
 def print_json(data) -> None:
     """Print data as formatted JSON to stdout."""
-    click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
 
 
 def truncate(text: str | None, length: int = 60) -> str:

--- a/airbnb/agent-harness/cli_web/airbnb/utils/json_group.py
+++ b/airbnb/agent-harness/cli_web/airbnb/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/airbnb/agent-harness/cli_web/airbnb/utils/json_group.py
+++ b/airbnb/agent-harness/cli_web/airbnb/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/amazon/agent-harness/.manifest.json
+++ b/amazon/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/amazon/agent-harness/.manifest.json
+++ b/amazon/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/amazon/agent-harness/.manifest.json
+++ b/amazon/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/amazon/agent-harness/cli_web/amazon/amazon_cli.py
+++ b/amazon/agent-harness/cli_web/amazon/amazon_cli.py
@@ -23,6 +23,7 @@ from .commands.product import product
 from .commands.search import search
 from .commands.suggest import suggest
 from .core.exceptions import AmazonError
+from .utils.json_group import JsonGroup
 from .utils.repl_skin import ReplSkin
 
 __version__ = "1.0.0"
@@ -52,7 +53,7 @@ def _print_repl_help():
     print()
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option(
     "--json", "json_mode", is_flag=True, default=False, help="Output all results as JSON."
 )

--- a/amazon/agent-harness/cli_web/amazon/utils/doctor.py
+++ b/amazon/agent-harness/cli_web/amazon/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/amazon/agent-harness/cli_web/amazon/utils/doctor.py
+++ b/amazon/agent-harness/cli_web/amazon/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/amazon/agent-harness/cli_web/amazon/utils/helpers.py
+++ b/amazon/agent-harness/cli_web/amazon/utils/helpers.py
@@ -26,7 +26,12 @@ CONFIG_FILE = CONFIG_DIR / "config.json"
 
 def print_json(data: Any) -> None:
     """Print data as pretty JSON."""
-    click.echo(json.dumps(data, ensure_ascii=False, indent=2))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, ensure_ascii=False, indent=2))
 
 
 # ---------------------------------------------------------------------------

--- a/amazon/agent-harness/cli_web/amazon/utils/json_group.py
+++ b/amazon/agent-harness/cli_web/amazon/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/amazon/agent-harness/cli_web/amazon/utils/json_group.py
+++ b/amazon/agent-harness/cli_web/amazon/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/amazon/agent-harness/cli_web/amazon/utils/output.py
+++ b/amazon/agent-harness/cli_web/amazon/utils/output.py
@@ -17,7 +17,12 @@ except ImportError:
 
 def print_json(data: Any) -> None:
     """Print data as pretty JSON."""
-    click.echo(json.dumps(data, ensure_ascii=False, indent=2))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, ensure_ascii=False, indent=2))
 
 
 def print_search_results(results, title: str = "Search Results") -> None:

--- a/booking/agent-harness/.manifest.json
+++ b/booking/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/booking/agent-harness/.manifest.json
+++ b/booking/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/booking/agent-harness/.manifest.json
+++ b/booking/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/booking/agent-harness/cli_web/booking/booking_cli.py
+++ b/booking/agent-harness/cli_web/booking/booking_cli.py
@@ -26,11 +26,12 @@ from . import __version__
 from .commands.auth_cmd import auth_group
 from .commands.properties import get_property
 from .commands.search import autocomplete, search_group
+from .utils.json_group import JsonGroup
 
 VERSION = __version__
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.version_option(VERSION, prog_name="cli-web-booking")
 @click.option("--json", "json_mode", is_flag=True, help="JSON output mode.")
 @click.pass_context

--- a/booking/agent-harness/cli_web/booking/tests/test_e2e.py
+++ b/booking/agent-harness/cli_web/booking/tests/test_e2e.py
@@ -232,9 +232,7 @@ class TestCLISubprocess:
         )
 
         if result.returncode != 0:
-            # May fail if cookies expired
-            print(f"Search failed: {result.stderr}")
-            pytest.skip("Search failed — WAF cookies may have expired")
+            pytest.fail(f"Search failed — WAF cookies may have expired: {result.stderr}")
 
         data = json.loads(result.stdout)
         assert data["success"] is True

--- a/booking/agent-harness/cli_web/booking/utils/doctor.py
+++ b/booking/agent-harness/cli_web/booking/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/booking/agent-harness/cli_web/booking/utils/doctor.py
+++ b/booking/agent-harness/cli_web/booking/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/booking/agent-harness/cli_web/booking/utils/helpers.py
+++ b/booking/agent-harness/cli_web/booking/utils/helpers.py
@@ -35,7 +35,12 @@ def json_error(code: str, message: str, **extra) -> str:
 
 def print_json(data) -> None:
     """Print JSON output."""
-    click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
 
 
 @contextmanager

--- a/booking/agent-harness/cli_web/booking/utils/json_group.py
+++ b/booking/agent-harness/cli_web/booking/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/booking/agent-harness/cli_web/booking/utils/json_group.py
+++ b/booking/agent-harness/cli_web/booking/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/capitoltrades/agent-harness/.manifest.json
+++ b/capitoltrades/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/capitoltrades/agent-harness/.manifest.json
+++ b/capitoltrades/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/capitoltrades/agent-harness/.manifest.json
+++ b/capitoltrades/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/capitoltrades/agent-harness/cli_web/capitoltrades/capitoltrades_cli.py
+++ b/capitoltrades/agent-harness/cli_web/capitoltrades/capitoltrades_cli.py
@@ -22,6 +22,7 @@ from .commands.issuers import issuers
 from .commands.politicians import politicians
 from .commands.press import press
 from .commands.trades import trades
+from .utils.json_group import JsonGroup
 from .utils.repl_skin import ReplSkin
 
 _skin = ReplSkin(app="capitoltrades", version="0.1.0")
@@ -30,7 +31,7 @@ _skin = ReplSkin(app="capitoltrades", version="0.1.0")
 # ── Main CLI group ─────────────────────────────────────────────────────────────
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
 @click.version_option("0.1.0", prog_name="cli-web-capitoltrades")
 @click.pass_context

--- a/capitoltrades/agent-harness/cli_web/capitoltrades/utils/doctor.py
+++ b/capitoltrades/agent-harness/cli_web/capitoltrades/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/capitoltrades/agent-harness/cli_web/capitoltrades/utils/doctor.py
+++ b/capitoltrades/agent-harness/cli_web/capitoltrades/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/capitoltrades/agent-harness/cli_web/capitoltrades/utils/helpers.py
+++ b/capitoltrades/agent-harness/cli_web/capitoltrades/utils/helpers.py
@@ -57,4 +57,9 @@ def handle_errors(json_mode: bool = False):
 
 def print_json(data) -> None:
     """Print data as formatted JSON to stdout."""
-    print(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))

--- a/capitoltrades/agent-harness/cli_web/capitoltrades/utils/json_group.py
+++ b/capitoltrades/agent-harness/cli_web/capitoltrades/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/capitoltrades/agent-harness/cli_web/capitoltrades/utils/json_group.py
+++ b/capitoltrades/agent-harness/cli_web/capitoltrades/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/chatgpt/agent-harness/.manifest.json
+++ b/chatgpt/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/chatgpt/agent-harness/.manifest.json
+++ b/chatgpt/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/chatgpt/agent-harness/.manifest.json
+++ b/chatgpt/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/chatgpt/agent-harness/cli_web/chatgpt/__main__.py
+++ b/chatgpt/agent-harness/cli_web/chatgpt/__main__.py
@@ -2,4 +2,5 @@
 
 from .chatgpt_cli import main
 
-main()
+if __name__ == "__main__":
+    main()

--- a/chatgpt/agent-harness/cli_web/chatgpt/chatgpt_cli.py
+++ b/chatgpt/agent-harness/cli_web/chatgpt/chatgpt_cli.py
@@ -22,12 +22,13 @@ from .commands.auth_cmd import auth_group
 from .commands.chat import chat_group
 from .commands.conversations import conversations_group
 from .commands.images import images_group
+from .utils.json_group import JsonGroup
 from .utils.repl_skin import ReplSkin
 
 _skin = ReplSkin("chatgpt", version="0.1.0")
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.version_option("0.1.0", prog_name="cli-web-chatgpt")
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
 @click.pass_context

--- a/chatgpt/agent-harness/cli_web/chatgpt/commands/auth_cmd.py
+++ b/chatgpt/agent-harness/cli_web/chatgpt/commands/auth_cmd.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import click
 
-from ..core.auth import clear_auth, is_logged_in, load_auth, login_browser
+from ..core.auth import clear_auth, is_logged_in, login_browser
 from ..utils.helpers import handle_errors
 from ..utils.output import print_json
 
@@ -21,7 +21,7 @@ def login(ctx) -> None:
     json_mode = ctx.obj.get("json", False) if ctx.obj else False
 
     with handle_errors(json_mode=json_mode):
-        auth_data = login_browser()
+        login_browser()
         if json_mode:
             print_json(
                 {
@@ -31,8 +31,6 @@ def login(ctx) -> None:
             )
         else:
             click.echo("Logged in successfully.")
-            if auth_data.get("device_id"):
-                click.echo(f"Device ID: {auth_data['device_id']}")
 
 
 @auth_group.command("status")
@@ -54,25 +52,15 @@ def status(ctx) -> None:
                 click.echo("Not logged in. Run: cli-web-chatgpt auth login")
             return
 
-        auth = load_auth()
-        token_preview = auth["access_token"][:20] + "..."
-        device_id = auth.get("device_id", "unknown")
-
         if json_mode:
             print_json(
                 {
                     "success": True,
-                    "data": {
-                        "logged_in": True,
-                        "device_id": device_id,
-                        "token_preview": token_preview,
-                    },
+                    "data": {"logged_in": True},
                 }
             )
         else:
             click.echo("Logged in.")
-            click.echo(f"Device ID: {device_id}")
-            click.echo(f"Token: {token_preview}")
 
 
 @auth_group.command("logout")

--- a/chatgpt/agent-harness/cli_web/chatgpt/core/client.py
+++ b/chatgpt/agent-harness/cli_web/chatgpt/core/client.py
@@ -111,6 +111,8 @@ class ChatGPTClient:
                 cookies=self._cookies(),
                 params=params,
             )
+        except AuthError:
+            raise
         except Exception as exc:
             raise NetworkError(f"Request failed: {exc}") from exc
 
@@ -140,6 +142,8 @@ class ChatGPTClient:
                 cookies=self._cookies(),
                 json=data or {},
             )
+        except AuthError:
+            raise
         except Exception as exc:
             raise NetworkError(f"Request failed: {exc}") from exc
 

--- a/chatgpt/agent-harness/cli_web/chatgpt/utils/doctor.py
+++ b/chatgpt/agent-harness/cli_web/chatgpt/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/chatgpt/agent-harness/cli_web/chatgpt/utils/doctor.py
+++ b/chatgpt/agent-harness/cli_web/chatgpt/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/chatgpt/agent-harness/cli_web/chatgpt/utils/json_group.py
+++ b/chatgpt/agent-harness/cli_web/chatgpt/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/chatgpt/agent-harness/cli_web/chatgpt/utils/json_group.py
+++ b/chatgpt/agent-harness/cli_web/chatgpt/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/chatgpt/agent-harness/cli_web/chatgpt/utils/output.py
+++ b/chatgpt/agent-harness/cli_web/chatgpt/utils/output.py
@@ -8,7 +8,12 @@ import click
 
 
 def print_json(data) -> None:
-    click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
 
 
 def truncate(text: str | None, length: int = 60) -> str:

--- a/cli-anything-web-plugin/.claude-plugin/plugin.json
+++ b/cli-anything-web-plugin/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "description": "CLI-Anything for the Web: Generate agent-native CLIs for closed-source web apps via network traffic analysis",
   "author": {
     "name": "Itamar",
-    "url": "https://github.com/itamar-earlyai"
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB"
   },
   "license": "MIT",
   "keywords": [

--- a/cli-anything-web-plugin/PUBLISHING.md
+++ b/cli-anything-web-plugin/PUBLISHING.md
@@ -34,22 +34,16 @@ cd ~/.claude/plugins
 tar -xzf cli-anything-web-plugin-v0.1.0.tar.gz
 ```
 
-## Option 2: GitHub Repository (Recommended)
+## Option 2: Install from the canonical GitHub repository
 
 ```bash
-cd cli-anything-web-plugin
-git init
-git add .
-git commit -m "Initial commit: cli-anything-web plugin v0.1.0"
-gh repo create cli-anything-web-plugin --public --source=. --remote=origin
-git push -u origin main
+git clone https://github.com/ItamarZand88/CLI-Anything-WEB.git
+cd CLI-Anything-WEB
+claude --plugin-dir "$PWD/cli-anything-web-plugin"
 ```
 
-Users can install directly:
-```bash
-cd ~/.claude/plugins
-git clone https://github.com/yourusername/cli-anything-web-plugin.git cli-anything-web
-```
+The plugin is maintained inside the monorepo. Do not publish the
+`cli-anything-web-plugin/` subdirectory as a separate repository.
 
 ## Publishing Generated CLIs to PyPI
 
@@ -106,6 +100,12 @@ CLI_WEB_FORCE_INSTALLED=1 python3 -m pytest cli_web/<app>/tests/ -v -s
 ```
 
 ### Publish to PyPI
+
+Packages in the canonical monorepo are released by Release Please and the
+`Publish to PyPI` GitHub Actions workflow. For a recovery publish, dispatch the
+workflow with the existing release tag; do not upload an untagged local tree.
+
+For a newly generated CLI outside the monorepo, the manual flow is:
 
 ```bash
 pip install build twine

--- a/cli-anything-web-plugin/scripts/doctor.py
+++ b/cli-anything-web-plugin/scripts/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/cli-anything-web-plugin/scripts/doctor.py
+++ b/cli-anything-web-plugin/scripts/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/cli-anything-web-plugin/scripts/json_group.py
+++ b/cli-anything-web-plugin/scripts/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/cli-anything-web-plugin/scripts/json_group.py
+++ b/cli-anything-web-plugin/scripts/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/cli-web-core/cli_web_core/doctor.py
+++ b/cli-web-core/cli_web_core/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/cli-web-core/cli_web_core/doctor.py
+++ b/cli-web-core/cli_web_core/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/cli-web-core/cli_web_core/json_group.py
+++ b/cli-web-core/cli_web_core/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/cli-web-core/cli_web_core/json_group.py
+++ b/cli-web-core/cli_web_core/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/cli-web-core/tests/test_json_group.py
+++ b/cli-web-core/tests/test_json_group.py
@@ -1,0 +1,47 @@
+import json
+
+import click
+from cli_web_core.json_group import JsonGroup
+from click.testing import CliRunner
+
+
+@click.group(cls=JsonGroup)
+@click.option("--json", "json_mode", is_flag=True)
+def cli(json_mode: bool) -> None:
+    """Test CLI."""
+
+
+@cli.command()
+@click.argument("value")
+def show(value: str) -> None:
+    click.echo(value)
+
+
+def test_json_usage_error_is_machine_readable() -> None:
+    result = CliRunner().invoke(cli, ["--json", "missing"])
+    assert result.exit_code == 2
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["code"] == "USAGE_ERROR"
+    assert "No such command" in payload["message"]
+
+
+def test_nested_missing_argument_is_machine_readable() -> None:
+    result = CliRunner().invoke(cli, ["--json", "show"])
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["code"] == "USAGE_ERROR"
+    assert "Missing argument" in payload["message"]
+
+
+def test_plain_usage_error_keeps_click_help() -> None:
+    result = CliRunner().invoke(cli, ["missing"])
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "No such command" in result.stderr
+
+
+def test_success_path_is_unchanged() -> None:
+    result = CliRunner().invoke(cli, ["show", "ok"])
+    assert result.exit_code == 0
+    assert result.stdout == "ok\n"

--- a/codewiki/agent-harness/.manifest.json
+++ b/codewiki/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/codewiki/agent-harness/.manifest.json
+++ b/codewiki/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/codewiki/agent-harness/.manifest.json
+++ b/codewiki/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/codewiki/agent-harness/cli_web/codewiki/codewiki_cli.py
+++ b/codewiki/agent-harness/cli_web/codewiki/codewiki_cli.py
@@ -26,12 +26,13 @@ import click
 from .commands.chat import chat_group
 from .commands.repos import repos
 from .commands.wiki import wiki_group
+from .utils.json_group import JsonGroup
 from .utils.repl_skin import ReplSkin
 
 _skin = ReplSkin("codewiki", version="0.1.0")
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.version_option("0.1.0", prog_name="cli-web-codewiki")
 @click.option(
     "--json",

--- a/codewiki/agent-harness/cli_web/codewiki/utils/doctor.py
+++ b/codewiki/agent-harness/cli_web/codewiki/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/codewiki/agent-harness/cli_web/codewiki/utils/doctor.py
+++ b/codewiki/agent-harness/cli_web/codewiki/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/codewiki/agent-harness/cli_web/codewiki/utils/json_group.py
+++ b/codewiki/agent-harness/cli_web/codewiki/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/codewiki/agent-harness/cli_web/codewiki/utils/json_group.py
+++ b/codewiki/agent-harness/cli_web/codewiki/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/codewiki/agent-harness/cli_web/codewiki/utils/output.py
+++ b/codewiki/agent-harness/cli_web/codewiki/utils/output.py
@@ -8,4 +8,9 @@ from typing import Any
 
 def print_json(data: Any) -> None:
     """Print data as formatted JSON to stdout."""
-    print(json.dumps(data, ensure_ascii=False, indent=2, default=str))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    print(json.dumps(payload, ensure_ascii=False, indent=2, default=str))

--- a/devkit/cli_web_devkit/canary.py
+++ b/devkit/cli_web_devkit/canary.py
@@ -47,7 +47,10 @@ class CanaryReport:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "ok": not self.failures,
+            # A target blocking a hosted-runner IP is diagnostic context, not
+            # fleet breakage. Keep JSON semantics aligned with the CLI exit
+            # code, which fails only when actionable `broken` results exist.
+            "ok": not self.broken,
             "total": len(self.results),
             "failed": len(self.failures),
             "broken": len(self.broken),

--- a/devkit/cli_web_devkit/sync.py
+++ b/devkit/cli_web_devkit/sync.py
@@ -35,6 +35,7 @@ SHARED_FILES: dict[str, str] = {
     "cli-web-core/cli_web_core/repl_skin.py": "utils/repl_skin.py",
     "cli-web-core/cli_web_core/mcp_server.py": "utils/mcp_server.py",
     "cli-web-core/cli_web_core/doctor.py": "utils/doctor.py",
+    "cli-web-core/cli_web_core/json_group.py": "utils/json_group.py",
 }
 
 # Non-CLI vendored copies that must also track canon (relative to repo root).
@@ -44,6 +45,7 @@ EXTRA_VENDOR_TARGETS: dict[str, str] = {
     "cli-web-core/cli_web_core/repl_skin.py": "cli-anything-web-plugin/scripts/repl_skin.py",
     "cli-web-core/cli_web_core/mcp_server.py": "cli-anything-web-plugin/scripts/mcp_server.py",
     "cli-web-core/cli_web_core/doctor.py": "cli-anything-web-plugin/scripts/doctor.py",
+    "cli-web-core/cli_web_core/json_group.py": "cli-anything-web-plugin/scripts/json_group.py",
 }
 
 

--- a/devkit/tests/test_canary.py
+++ b/devkit/tests/test_canary.py
@@ -129,6 +129,7 @@ def test_run_canaries_antibot_block_is_not_broken(tmp_path, monkeypatch):
     report = run_canaries(root)
     assert report.blocked and not report.broken
     assert report.blocked[0].status == "blocked"
+    assert report.to_dict()["ok"] is True
 
 
 def test_run_canaries_logic_break_is_broken(tmp_path, monkeypatch):

--- a/futbin/agent-harness/.manifest.json
+++ b/futbin/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/futbin/agent-harness/.manifest.json
+++ b/futbin/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/futbin/agent-harness/.manifest.json
+++ b/futbin/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/futbin/agent-harness/cli_web/futbin/commands/market.py
+++ b/futbin/agent-harness/cli_web/futbin/commands/market.py
@@ -313,7 +313,7 @@ def scan(rating_min, rating_max, platform, limit, threshold, use_json):
             from rich.progress import Progress
 
             results = []
-            with Progress() as progress:
+            with Progress(disable=use_json) as progress:
                 task = progress.add_task("Analyzing players...", total=len(candidates))
                 for p in candidates:
                     try:

--- a/futbin/agent-harness/cli_web/futbin/commands/players.py
+++ b/futbin/agent-harness/cli_web/futbin/commands/players.py
@@ -234,7 +234,7 @@ def versions(name, year, use_json):
             from rich.progress import Progress
 
             detailed = []
-            with Progress() as progress:
+            with Progress(disable=use_json) as progress:
                 task = progress.add_task(
                     f"Fetching {len(candidates)} versions...", total=len(candidates)
                 )

--- a/futbin/agent-harness/cli_web/futbin/core/client.py
+++ b/futbin/agent-harness/cli_web/futbin/core/client.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import atexit
 import re
 import time
 from typing import Any
+from urllib.parse import urlencode
 
 import httpx
 from bs4 import BeautifulSoup
+from camoufox.sync_api import Camoufox
 from cli_web.futbin.core.models import (
     SBC,
     Evolution,
@@ -22,6 +25,7 @@ from cli_web.futbin.core.models import (
 )
 
 from .exceptions import (
+    FutbinError,
     NetworkError,
     NotFoundError,
     ParsingError,
@@ -67,6 +71,9 @@ class FutbinClient:
             timeout=30.0,
         )
         self._last_request = 0.0
+        self._browser_cm = None
+        self._browser = None
+        self._page = None
 
     BASE_URL = BASE_URL
 
@@ -84,6 +91,8 @@ class FutbinClient:
         except httpx.RequestError as exc:
             raise NetworkError(f"Request error: {exc}") from exc
         self._last_request = time.time()
+        if resp.status_code == 403:
+            return self._browser_get(path, params)  # type: ignore[return-value]
         if resp.status_code == 429:
             retry_after = resp.headers.get("Retry-After")
             raise RateLimitError(
@@ -98,6 +107,62 @@ class FutbinClient:
             )
         resp.raise_for_status()
         return resp
+
+    def _ensure_browser(self) -> None:
+        """Start a stealth browser and clear Cloudflare once per process."""
+        if self._page is not None:
+            return
+        try:
+            self._browser_cm = Camoufox(headless=True)
+            self._browser = self._browser_cm.__enter__()
+            self._page = self._browser.new_page()
+            self._page.goto(BASE_URL, wait_until="domcontentloaded", timeout=45000)
+            if self._page.title() == "Just a moment...":
+                self._page.wait_for_function("document.title !== 'Just a moment...'", timeout=45000)
+        except Exception as exc:
+            self._close_browser()
+            raise NetworkError(f"Failed to clear FUTBIN browser challenge: {exc}") from exc
+        atexit.register(self._close_browser)
+
+    def _browser_get(self, path: str, params: dict | None = None):
+        """Fetch through the cleared browser session and return a response shim."""
+        self._ensure_browser()
+        url = path if path.startswith("http") else f"{BASE_URL}{path}"
+        if params:
+            url = f"{url}?{urlencode({k: v for k, v in params.items() if v is not None})}"
+        try:
+            response = self._page.goto(url, wait_until="domcontentloaded", timeout=45000)
+            if response is None:
+                raise NetworkError(f"No response for {url}")
+            status = response.status
+            try:
+                body = response.text()
+            except Exception:
+                # Playwright does not expose bodies for intermediate redirects;
+                # page.content() is the final document after navigation.
+                body = (
+                    self._page.locator("body").inner_text()
+                    if path.startswith("/players/search")
+                    else self._page.content()
+                )
+                status = 200
+            headers = response.headers
+        except FutbinError:
+            raise
+        except Exception as exc:
+            raise NetworkError(f"Browser request failed: {exc}") from exc
+        if status == 403:
+            raise NetworkError("FUTBIN's Cloudflare challenge could not be cleared")
+        return _BrowserResponse(status, body, headers)
+
+    def _close_browser(self) -> None:
+        if self._browser_cm is not None:
+            try:
+                self._browser_cm.__exit__(None, None, None)
+            except Exception:
+                pass
+            finally:
+                self._browser_cm = self._browser = self._page = None
 
     def _soup(self, path: str, params: dict | None = None) -> BeautifulSoup:
         resp = self._get(path, params)
@@ -1210,9 +1275,28 @@ class FutbinClient:
 
     def close(self):
         self._client.close()
+        self._close_browser()
 
     def __enter__(self):
         return self
 
     def __exit__(self, *args):
         self.close()
+
+
+class _BrowserResponse:
+    """Small httpx-compatible surface used by the existing parsers."""
+
+    def __init__(self, status_code: int, text: str, headers: dict):
+        self.status_code = status_code
+        self.text = text
+        self.headers = headers
+
+    def json(self):
+        import json
+
+        return json.loads(self.text)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise NetworkError(f"HTTP {self.status_code} from FUTBIN")

--- a/futbin/agent-harness/cli_web/futbin/futbin_cli.py
+++ b/futbin/agent-harness/cli_web/futbin/futbin_cli.py
@@ -32,13 +32,15 @@ from cli_web.futbin.commands.players import players
 from cli_web.futbin.commands.sbc import sbc
 from cli_web.futbin.utils.repl_skin import ReplSkin
 
+from .utils.json_group import JsonGroup
+
 VERSION = "0.1.0"
 APP_NAME = "futbin"
 
 _skin = ReplSkin(APP_NAME, version=VERSION)
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, default=False, help="Output as JSON.")
 @click.version_option(VERSION, prog_name="cli-web-futbin")
 @click.pass_context

--- a/futbin/agent-harness/cli_web/futbin/tests/test_e2e.py
+++ b/futbin/agent-harness/cli_web/futbin/tests/test_e2e.py
@@ -19,9 +19,7 @@ def _resolve_cli(name: str) -> list[str]:
         found = shutil.which(name)
         if found:
             return [found]
-        # Fall back to python -m
-        pkg = name.replace("cli-web-", "cli_web.").replace("-", "_")
-        return [sys.executable, "-m", pkg]
+        raise FileNotFoundError(f"{name} not found in PATH")
 
     # Development: use python -m
     pkg = "cli_web.futbin"
@@ -42,6 +40,13 @@ def _run(*args: str, check: bool = True) -> subprocess.CompletedProcess:
 
 
 # ── CLI Subprocess Tests ──────────────────────────────────────────────────────
+
+
+class TestCLISubprocess:
+    def test_cli_help(self):
+        result = _run("--help")
+        assert result.returncode == 0
+        assert "futbin" in result.stdout.lower() or "players" in result.stdout.lower()
 
 
 def test_cli_help():

--- a/futbin/agent-harness/cli_web/futbin/utils/doctor.py
+++ b/futbin/agent-harness/cli_web/futbin/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/futbin/agent-harness/cli_web/futbin/utils/doctor.py
+++ b/futbin/agent-harness/cli_web/futbin/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/futbin/agent-harness/cli_web/futbin/utils/json_group.py
+++ b/futbin/agent-harness/cli_web/futbin/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/futbin/agent-harness/cli_web/futbin/utils/json_group.py
+++ b/futbin/agent-harness/cli_web/futbin/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/futbin/agent-harness/cli_web/futbin/utils/output.py
+++ b/futbin/agent-harness/cli_web/futbin/utils/output.py
@@ -9,7 +9,12 @@ from typing import Any
 
 def print_json(data: Any) -> None:
     """Print data as indented JSON to stdout."""
-    print(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
 
 
 def print_table(

--- a/futbin/agent-harness/setup.py
+++ b/futbin/agent-harness/setup.py
@@ -11,6 +11,9 @@ setup(
     install_requires=[
         "click>=8.0",
         "httpx>=0.24",
+        # FUTBIN's Cloudflare edge requires a real browser when it challenges
+        # the plain HTTP transport. Keep this aligned with the canary cache.
+        "camoufox==0.5.4",
         "beautifulsoup4>=4.12",
         "rich>=13.0",
         "prompt_toolkit>=3.0",

--- a/gai/agent-harness/.manifest.json
+++ b/gai/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/gai/agent-harness/.manifest.json
+++ b/gai/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/gai/agent-harness/.manifest.json
+++ b/gai/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/gai/agent-harness/cli_web/gai/core/client.py
+++ b/gai/agent-harness/cli_web/gai/core/client.py
@@ -203,6 +203,19 @@ class GAIClient:
                 if (text) parts.push(text);
             }
 
+            // Google changes the answer's generated class names frequently.
+            // Fall back to the semantic turn container instead of returning a
+            // false-success empty answer when .Y3BBE has changed.
+            if (parts.length === 0) {
+                const clone = lastTurn.cloneNode(true);
+                for (const el of clone.querySelectorAll(
+                    'button, textarea, input, [role=button], script, style'
+                )) el.remove();
+                let text = (clone.innerText || '').trim();
+                text = text.split('AI can make mistakes')[0].trim();
+                if (text) parts.push(text);
+            }
+
             // Extract source links \u2014 handle Google redirect URLs and empty-text links
             const sources = [];
             const seen = new Set();
@@ -289,9 +302,13 @@ class GAIClient:
             for s in result.get("sources", [])
         ]
 
+        answer = result.get("answer", "").strip()
+        if not answer:
+            raise ParseError("Google returned an AI turn, but its answer could not be extracted.")
+
         return SearchResult(
             query=query,
-            answer=result.get("answer", ""),
+            answer=answer,
             sources=sources,
             follow_up_prompt=result.get("followUp", ""),
         )

--- a/gai/agent-harness/cli_web/gai/gai_cli.py
+++ b/gai/agent-harness/cli_web/gai/gai_cli.py
@@ -19,12 +19,13 @@ import shlex
 import click
 
 from .commands.search import close_client, search_group
+from .utils.json_group import JsonGroup
 from .utils.repl_skin import ReplSkin
 
 _skin = ReplSkin(app="gai", version="0.1.0")
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
 @click.version_option(package_name="cli-web-gai")
 @click.pass_context

--- a/gai/agent-harness/cli_web/gai/utils/doctor.py
+++ b/gai/agent-harness/cli_web/gai/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/gai/agent-harness/cli_web/gai/utils/doctor.py
+++ b/gai/agent-harness/cli_web/gai/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/gai/agent-harness/cli_web/gai/utils/helpers.py
+++ b/gai/agent-harness/cli_web/gai/utils/helpers.py
@@ -63,4 +63,9 @@ def handle_errors(json_mode: bool = False):
 
 def print_json(data: dict):
     """Print formatted JSON to stdout."""
-    click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False))

--- a/gai/agent-harness/cli_web/gai/utils/json_group.py
+++ b/gai/agent-harness/cli_web/gai/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/gai/agent-harness/cli_web/gai/utils/json_group.py
+++ b/gai/agent-harness/cli_web/gai/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/gh-trending/agent-harness/.manifest.json
+++ b/gh-trending/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/gh-trending/agent-harness/.manifest.json
+++ b/gh-trending/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/gh-trending/agent-harness/.manifest.json
+++ b/gh-trending/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/gh-trending/agent-harness/cli_web/gh_trending/gh_trending_cli.py
+++ b/gh-trending/agent-harness/cli_web/gh_trending/gh_trending_cli.py
@@ -23,13 +23,15 @@ from cli_web.gh_trending.commands.repos import repos_group
 from cli_web.gh_trending.core.exceptions import AppError
 from cli_web.gh_trending.utils.repl_skin import ReplSkin
 
+from .utils.json_group import JsonGroup
+
 _skin = ReplSkin(app="gh_trending", version="0.1.0", display_name="GitHub Trending")
 
 
 # ---------------------------------------------------------------------------- main CLI
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON (applies to all commands).")
 @click.version_option("0.1.0", prog_name="cli-web-gh-trending")
 @click.pass_context

--- a/gh-trending/agent-harness/cli_web/gh_trending/tests/test_e2e.py
+++ b/gh-trending/agent-harness/cli_web/gh_trending/tests/test_e2e.py
@@ -124,6 +124,8 @@ class TestCLISubprocess:
             capture_output=True,
             text=True,
             check=check,
+            encoding="utf-8",
+            errors="replace",
         )
 
     def test_help(self):

--- a/gh-trending/agent-harness/cli_web/gh_trending/utils/doctor.py
+++ b/gh-trending/agent-harness/cli_web/gh_trending/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/gh-trending/agent-harness/cli_web/gh_trending/utils/doctor.py
+++ b/gh-trending/agent-harness/cli_web/gh_trending/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/gh-trending/agent-harness/cli_web/gh_trending/utils/helpers.py
+++ b/gh-trending/agent-harness/cli_web/gh_trending/utils/helpers.py
@@ -50,7 +50,12 @@ def resolve_json_mode(use_json: bool) -> bool:
 
 def print_json(data) -> None:
     """Print data as formatted JSON."""
-    click.echo(json.dumps(data, indent=2, default=str))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, indent=2, default=str))
 
 
 def print_error_json(exc: AppError) -> None:

--- a/gh-trending/agent-harness/cli_web/gh_trending/utils/json_group.py
+++ b/gh-trending/agent-harness/cli_web/gh_trending/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/gh-trending/agent-harness/cli_web/gh_trending/utils/json_group.py
+++ b/gh-trending/agent-harness/cli_web/gh_trending/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/gh-trending/agent-harness/cli_web/gh_trending/utils/output.py
+++ b/gh-trending/agent-harness/cli_web/gh_trending/utils/output.py
@@ -17,7 +17,12 @@ def _safe(text: str, width: int = 0) -> str:
 
 def print_json(data: Any) -> None:
     """Print data as formatted JSON to stdout."""
-    print(json.dumps(data, indent=2, default=str))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    print(json.dumps(payload, indent=2, default=str))
 
 
 def print_json_success(data: Any) -> None:

--- a/hackernews/agent-harness/.manifest.json
+++ b/hackernews/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/hackernews/agent-harness/.manifest.json
+++ b/hackernews/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/hackernews/agent-harness/.manifest.json
+++ b/hackernews/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/hackernews/agent-harness/cli_web/hackernews/commands/stories.py
+++ b/hackernews/agent-harness/cli_web/hackernews/commands/stories.py
@@ -53,6 +53,33 @@ def stories_new(ctx, limit, json_mode):
             click.echo(f"\n{len(stories)} stories\n")
 
 
+@stories_group.command("max-item")
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
+def max_item(json_mode):
+    """Show the largest current Hacker News item ID."""
+    json_mode = resolve_json_mode(json_mode)
+    with handle_errors(json_mode=json_mode), HackerNewsClient() as client:
+        item_id = client.get_max_item_id()
+        if json_mode:
+            print_json({"max_item_id": item_id})
+        else:
+            click.echo(item_id)
+
+
+@stories_group.command("updates")
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
+def updates(json_mode):
+    """Show recently changed item and user IDs."""
+    json_mode = resolve_json_mode(json_mode)
+    with handle_errors(json_mode=json_mode), HackerNewsClient() as client:
+        data = client.get_updates()
+        if json_mode:
+            print_json(data)
+        else:
+            click.echo(f"Items: {', '.join(map(str, data.get('items', [])))}")
+            click.echo(f"Profiles: {', '.join(data.get('profiles', []))}")
+
+
 @stories_group.command("best")
 @click.option("-n", "--limit", default=30, show_default=True, help="Number of stories to show.")
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")

--- a/hackernews/agent-harness/cli_web/hackernews/core/client.py
+++ b/hackernews/agent-harness/cli_web/hackernews/core/client.py
@@ -107,6 +107,14 @@ class HackerNewsClient:
         ids = self.get_story_ids(feed)[:limit]
         return self._fetch_items_parallel(ids, Story)
 
+    def get_max_item_id(self) -> int:
+        """Return the current largest item ID."""
+        return int(self._get_json(f"{FIREBASE_BASE}/maxitem.json"))
+
+    def get_updates(self) -> dict:
+        """Return recently changed item and profile IDs."""
+        return self._get_json(f"{FIREBASE_BASE}/updates.json")
+
     # ------------------------------------------------------------------ items
 
     def get_item(self, item_id: int) -> dict:

--- a/hackernews/agent-harness/cli_web/hackernews/hackernews_cli.py
+++ b/hackernews/agent-harness/cli_web/hackernews/hackernews_cli.py
@@ -32,13 +32,15 @@ from cli_web.hackernews.commands.user import user_group
 from cli_web.hackernews.core.exceptions import AppError
 from cli_web.hackernews.utils.repl_skin import ReplSkin
 
+from .utils.json_group import JsonGroup
+
 _skin = ReplSkin(app="hackernews", version="0.2.0", display_name="Hacker News")
 
 
 # ---------------------------------------------------------------------------- main CLI
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON (applies to all commands).")
 @click.version_option("0.2.0", prog_name="cli-web-hackernews")
 @click.pass_context

--- a/hackernews/agent-harness/cli_web/hackernews/tests/test_e2e.py
+++ b/hackernews/agent-harness/cli_web/hackernews/tests/test_e2e.py
@@ -144,7 +144,7 @@ class TestSearchE2E:
 # ─── Subprocess Tests ───────────────────────────────────────────────────────
 
 
-class TestSubprocess:
+class TestCLISubprocess:
     def _run(self, args: str, timeout: int = 30) -> subprocess.CompletedProcess:
         cli_path = _resolve_cli("cli-web-hackernews")
         cmd = f"{cli_path} {args}"
@@ -154,6 +154,8 @@ class TestSubprocess:
             capture_output=True,
             text=True,
             timeout=timeout,
+            encoding="utf-8",
+            errors="replace",
         )
 
     def test_version(self):

--- a/hackernews/agent-harness/cli_web/hackernews/utils/doctor.py
+++ b/hackernews/agent-harness/cli_web/hackernews/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/hackernews/agent-harness/cli_web/hackernews/utils/doctor.py
+++ b/hackernews/agent-harness/cli_web/hackernews/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/hackernews/agent-harness/cli_web/hackernews/utils/helpers.py
+++ b/hackernews/agent-harness/cli_web/hackernews/utils/helpers.py
@@ -52,7 +52,12 @@ def resolve_json_mode(use_json: bool) -> bool:
 
 def print_json(data) -> None:
     """Print data as formatted JSON."""
-    click.echo(json.dumps(data, indent=2, default=str))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, indent=2, default=str))
 
 
 def _resolve_cli(name: str) -> str:

--- a/hackernews/agent-harness/cli_web/hackernews/utils/json_group.py
+++ b/hackernews/agent-harness/cli_web/hackernews/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/hackernews/agent-harness/cli_web/hackernews/utils/json_group.py
+++ b/hackernews/agent-harness/cli_web/hackernews/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/hackernews/agent-harness/cli_web/hackernews/utils/output.py
+++ b/hackernews/agent-harness/cli_web/hackernews/utils/output.py
@@ -17,7 +17,12 @@ def _safe(text: str, width: int = 0) -> str:
 
 def print_json(data: Any) -> None:
     """Print data as formatted JSON to stdout."""
-    print(json.dumps(data, indent=2, default=str))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    print(json.dumps(payload, indent=2, default=str))
 
 
 def print_error_json(error: Exception) -> None:

--- a/linkedin/agent-harness/.manifest.json
+++ b/linkedin/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/linkedin/agent-harness/.manifest.json
+++ b/linkedin/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/linkedin/agent-harness/.manifest.json
+++ b/linkedin/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/linkedin/agent-harness/LINKEDIN.md
+++ b/linkedin/agent-harness/LINKEDIN.md
@@ -141,7 +141,7 @@ cli-web-linkedin
 ├── feed [--count N]               # View feed posts with likes/comments
 ├── profile get <username>         # View user profile
 ├── profile me                     # View own profile
-├── company <name>                 # View company page (via search)
+├── company get <name>             # View company page (via search)
 ├── company follow <urn>           # Follow a company
 ├── company unfollow <urn>         # Unfollow a company
 ├── jobs search <query>            # Search jobs (REST)

--- a/linkedin/agent-harness/cli_web/linkedin/commands/company.py
+++ b/linkedin/agent-harness/cli_web/linkedin/commands/company.py
@@ -8,20 +8,17 @@ from ..core.client import LinkedinClient
 from ..utils.helpers import get_text, handle_errors, print_json, resolve_json_mode
 
 
-@click.group("company", invoke_without_command=True)
-@click.argument("name", required=False)
+@click.group("company")
+def company():
+    """View, follow, or unfollow companies."""
+
+
+@company.command("get")
+@click.argument("name")
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
 @click.pass_context
-def company(ctx, name, json_mode):
-    """View a company page, or follow/unfollow companies."""
-    ctx.ensure_object(dict)
-    if json_mode:
-        ctx.obj["json"] = True
-    if ctx.invoked_subcommand is not None:
-        return
-    if not name:
-        click.echo(ctx.get_help())
-        return
+def get_company(ctx, name, json_mode):
+    """View a company page by name or slug."""
     json_mode = resolve_json_mode(json_mode, ctx)
     with handle_errors(json_mode):
         with LinkedinClient() as client:

--- a/linkedin/agent-harness/cli_web/linkedin/linkedin_cli.py
+++ b/linkedin/agent-harness/cli_web/linkedin/linkedin_cli.py
@@ -16,6 +16,7 @@ import shlex
 
 import click
 
+from .utils.json_group import JsonGroup
 from .utils.repl_skin import ReplSkin
 
 _skin = ReplSkin("linkedin", version="0.1.0")
@@ -24,7 +25,7 @@ _skin = ReplSkin("linkedin", version="0.1.0")
 # ── Main CLI group ─────────────────────────────────────────────────────────────
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
 @click.version_option("0.1.0", prog_name="cli-web-linkedin")
 @click.pass_context
@@ -39,7 +40,7 @@ def cli(ctx, json_mode):
       cli-web-linkedin feed --json
       cli-web-linkedin post create "Hello LinkedIn!"
       cli-web-linkedin jobs search "software engineer" --limit 5
-      cli-web-linkedin company anthropic --json
+      cli-web-linkedin company get anthropic --json
     """
     ctx.ensure_object(dict)
     ctx.obj["json"] = json_mode
@@ -144,7 +145,7 @@ def _print_repl_help() -> None:
     print("  profile get USERNAME          View a LinkedIn profile")
     print("  profile me                    View your own profile")
     print()
-    print("  company NAME                  View a company page")
+    print("  company get NAME              View a company page")
     print("  company follow COMPANY_URN    Follow a company")
     print("  company unfollow COMPANY_URN  Unfollow a company")
     print()

--- a/linkedin/agent-harness/cli_web/linkedin/tests/test_core.py
+++ b/linkedin/agent-harness/cli_web/linkedin/tests/test_core.py
@@ -227,31 +227,29 @@ class TestModels:
 class TestHelpers:
     """Verify handle_errors context manager and resolve_json_mode."""
 
-    def test_handle_errors_catches_auth_error_exit_1(self):
+    def test_handle_errors_catches_auth_error_exit_3(self):
         with pytest.raises(SystemExit) as exc_info:
             with handle_errors():
                 raise AuthError("expired")
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == 3
 
-    def test_handle_errors_catches_not_found_error_exit_1(self):
+    def test_handle_errors_catches_not_found_error_exit_4(self):
         with pytest.raises(SystemExit) as exc_info:
             with handle_errors():
                 raise NotFoundError("no such user")
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == 4
 
-    def test_handle_errors_catches_server_error_exit_2(self):
-        """ServerError is a LinkedinError so exits with code 1."""
+    def test_handle_errors_catches_server_error_exit_6(self):
         with pytest.raises(SystemExit) as exc_info:
             with handle_errors():
                 raise ServerError("internal error", status_code=500)
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == 6
 
-    def test_handle_errors_catches_network_error_exit_1(self):
-        """NetworkError is a LinkedinError so exits with code 1."""
+    def test_handle_errors_catches_network_error_exit_7(self):
         with pytest.raises(SystemExit) as exc_info:
             with handle_errors():
                 raise NetworkError("DNS failed")
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == 7
 
     def test_handle_errors_catches_generic_exception_exit_2(self):
         with pytest.raises(SystemExit) as exc_info:

--- a/linkedin/agent-harness/cli_web/linkedin/utils/doctor.py
+++ b/linkedin/agent-harness/cli_web/linkedin/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/linkedin/agent-harness/cli_web/linkedin/utils/doctor.py
+++ b/linkedin/agent-harness/cli_web/linkedin/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/linkedin/agent-harness/cli_web/linkedin/utils/helpers.py
+++ b/linkedin/agent-harness/cli_web/linkedin/utils/helpers.py
@@ -9,7 +9,14 @@ from contextlib import contextmanager
 
 import click
 
-from ..core.exceptions import LinkedinError
+from ..core.exceptions import (
+    AuthError,
+    LinkedinError,
+    NetworkError,
+    NotFoundError,
+    RateLimitError,
+    ServerError,
+)
 
 
 # --- Windows UTF-8 fix (always include) ---
@@ -46,7 +53,18 @@ def handle_errors(json_mode: bool = False):
             print_json(exc.to_dict())
         else:
             click.secho(f"Error: {exc}", fg="red", err=True)
-        raise SystemExit(1) from exc
+        exit_code = 1
+        if isinstance(exc, AuthError):
+            exit_code = 3
+        elif isinstance(exc, NotFoundError):
+            exit_code = 4
+        elif isinstance(exc, RateLimitError):
+            exit_code = 5
+        elif isinstance(exc, ServerError):
+            exit_code = 6
+        elif isinstance(exc, NetworkError):
+            exit_code = 7
+        raise SystemExit(exit_code) from exc
     except Exception as exc:
         if json_mode:
             print_json({"error": True, "code": "INTERNAL_ERROR", "message": str(exc)})
@@ -67,7 +85,12 @@ def resolve_json_mode(json_mode: bool, ctx: click.Context | None = None) -> bool
 
 def print_json(data) -> None:
     """Print data as formatted JSON to stdout."""
-    print(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
 
 
 def get_text(obj, *keys) -> str:

--- a/linkedin/agent-harness/cli_web/linkedin/utils/json_group.py
+++ b/linkedin/agent-harness/cli_web/linkedin/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/linkedin/agent-harness/cli_web/linkedin/utils/json_group.py
+++ b/linkedin/agent-harness/cli_web/linkedin/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/notebooklm/agent-harness/.manifest.json
+++ b/notebooklm/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/notebooklm/agent-harness/.manifest.json
+++ b/notebooklm/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/notebooklm/agent-harness/.manifest.json
+++ b/notebooklm/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/notebooklm/agent-harness/cli_web/notebooklm/core/auth.py
+++ b/notebooklm/agent-harness/cli_web/notebooklm/core/auth.py
@@ -345,6 +345,30 @@ def load_cookies() -> dict:
         raise AuthError(f"Corrupted auth file: {e}. Run: cli-web-notebooklm auth login") from e
 
 
+def refresh_auth() -> dict:
+    """Refresh stored cookies from the persistent browser profile headlessly."""
+    try:
+        from playwright.sync_api import sync_playwright
+
+        with _windows_playwright_event_loop(), sync_playwright() as playwright:
+            context = playwright.chromium.launch_persistent_context(
+                user_data_dir=str(BROWSER_PROFILE_DIR),
+                headless=True,
+                args=["--disable-blink-features=AutomationControlled"],
+                ignore_default_args=["--enable-automation"],
+            )
+            page = context.pages[0] if context.pages else context.new_page()
+            page.goto(BASE_URL, wait_until="domcontentloaded", timeout=30000)
+            cookies = _extract_cookies(context.cookies())
+            context.close()
+    except Exception as exc:
+        raise AuthError(f"Headless auth refresh failed: {exc}", recoverable=False) from exc
+    if not cookies:
+        raise AuthError("Session expired — run: cli-web-notebooklm auth login", recoverable=False)
+    _save_auth({"cookies": cookies})
+    return cookies
+
+
 def fetch_tokens(cookies: dict) -> tuple[str, str, str]:
     """Fetch and extract CSRF token, session ID, and build label from homepage.
 

--- a/notebooklm/agent-harness/cli_web/notebooklm/core/client.py
+++ b/notebooklm/agent-harness/cli_web/notebooklm/core/client.py
@@ -6,8 +6,9 @@ from typing import Any
 
 import httpx
 
-from .auth import fetch_tokens, fetch_user_info, load_cookies
+from .auth import fetch_tokens, fetch_user_info, load_cookies, refresh_auth
 from .exceptions import (
+    AuthError,
     NetworkError,
     NotebookLMError,
     NotFoundError,
@@ -72,6 +73,7 @@ class NotebookLMClient:
         params: list,
         source_path: str = "/",
         retry_on_auth: bool = True,
+        _auth_attempt: int = 0,
     ) -> Any:
         """Execute a batchexecute RPC call.
 
@@ -123,9 +125,27 @@ class NotebookLMClient:
         except httpx.RequestError as e:
             raise NetworkError(f"Network error: {e}") from e
 
-        if resp.status_code in (401, 403) and retry_on_auth:
+        if resp.status_code in (401, 403):
+            if not retry_on_auth or _auth_attempt >= 2:
+                raise AuthError(
+                    "NotebookLM session expired after automatic refresh", recoverable=False
+                )
+            if _auth_attempt == 0:
+                try:
+                    self._cookies = load_cookies()
+                except AuthError:
+                    pass  # Keep the in-memory cookies when no disk source exists.
+            else:
+                self._cookies = refresh_auth()
+            self._csrf = self._session_id = self._build_label = None
             self._refresh_tokens()
-            return self._call(rpc_id, params, source_path, retry_on_auth=False)
+            return self._call(
+                rpc_id,
+                params,
+                source_path,
+                retry_on_auth=True,
+                _auth_attempt=_auth_attempt + 1,
+            )
 
         if resp.status_code == 404:
             raise NotFoundError(f"Not found: {resp.text[:200]}")
@@ -317,7 +337,7 @@ class NotebookLMClient:
     def ask(self, notebook_id: str, query: str) -> str:
         return self.chat_query(notebook_id, query)
 
-    def chat_query(self, notebook_id: str, query: str) -> str:
+    def chat_query(self, notebook_id: str, query: str, _auth_attempt: int = 0) -> str:
         """Ask a question to a notebook.
 
         Uses GenerateFreeFormStreamed endpoint.
@@ -378,8 +398,20 @@ class NotebookLMClient:
             raise NetworkError(f"Network error: {e}") from e
 
         if resp.status_code in (401, 403):
+            if _auth_attempt >= 2:
+                raise AuthError(
+                    "NotebookLM session expired after automatic refresh", recoverable=False
+                )
+            if _auth_attempt == 0:
+                try:
+                    self._cookies = load_cookies()
+                except AuthError:
+                    pass
+            else:
+                self._cookies = refresh_auth()
+            self._csrf = self._session_id = self._build_label = None
             self._refresh_tokens()
-            return self.chat_query(notebook_id, query)
+            return self.chat_query(notebook_id, query, _auth_attempt=_auth_attempt + 1)
 
         if resp.status_code == 429:
             raise RateLimitError("Rate limited — please wait and try again")

--- a/notebooklm/agent-harness/cli_web/notebooklm/notebooklm_cli.py
+++ b/notebooklm/agent-harness/cli_web/notebooklm/notebooklm_cli.py
@@ -27,8 +27,8 @@ from .core.auth import (
     login_from_cookies_json,
 )
 from .core.client import NotebookLMClient
-from .core.exceptions import AuthError, NotebookLMError
-from .utils.output import error, handle_error, print_json, print_user
+from .utils.json_group import JsonGroup
+from .utils.output import print_json, print_user
 from .utils.repl_skin import ReplSkin
 
 APP_NAME = "notebooklm"
@@ -37,19 +37,22 @@ VERSION = "0.1.0"
 _skin = ReplSkin(APP_NAME, version=VERSION)
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
 @click.version_option("0.1.0", prog_name="cli-web-notebooklm")
 @click.pass_context
-def main(ctx):
+def main(ctx, json_mode):
     """cli-web-notebooklm — NotebookLM CLI.
 
     Run without a subcommand to enter interactive REPL mode.
     """
+    ctx.ensure_object(dict)
+    ctx.obj["json"] = json_mode
     if ctx.invoked_subcommand is None:
-        _run_repl()
+        _run_repl(json_mode)
 
 
-def _run_repl():
+def _run_repl(json_mode=False):
     """Interactive REPL mode."""
     _skin.print_banner()
     _skin.info("Type 'help' for available commands, 'quit' to exit.")
@@ -71,6 +74,8 @@ def _run_repl():
             continue
 
         args = shlex.split(line)
+        if json_mode:
+            args = ["--json", *args]
         try:
             main.main(args, standalone_mode=False, prog_name="cli-web-notebooklm")
         except SystemExit:
@@ -118,6 +123,7 @@ def _print_repl_help():
     print("    whoami                                         Show current user")
     print("    auth login                                     Login via browser")
     print("    auth status                                    Check auth status")
+    print("    auth refresh                                   Refresh session tokens")
     print("  quit                                             Exit REPL")
 
 
@@ -140,15 +146,20 @@ def auth():
 
 @auth.command("login")
 @click.option("--cookies-json", default=None, help="Import cookies from a JSON file")
-def auth_login(cookies_json):
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def auth_login(ctx, cookies_json, as_json):
     """Log in to NotebookLM via browser (Google account required)."""
-    try:
+    from .utils.helpers import handle_errors
+
+    as_json = as_json or bool((ctx.find_root().obj or {}).get("json"))
+    with handle_errors(json_mode=as_json):
         if cookies_json:
             login_from_cookies_json(cookies_json)
         else:
             login_browser()
-    except AuthError as e:
-        error(str(e))
+        if as_json:
+            print_json({"logged_in": True})
 
 
 @auth.command("status")
@@ -173,13 +184,18 @@ def auth_status(as_json):
 
 
 @auth.command("refresh")
-def auth_refresh():
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def auth_refresh(ctx, as_json):
     """Re-extract CSRF and session tokens from NotebookLM homepage.
 
     This refreshes tokens when they've rotated but cookies are still valid.
     If cookies themselves have expired, run 'auth login' instead.
     """
-    try:
+    from .utils.helpers import handle_errors
+
+    as_json = as_json or bool((ctx.find_root().obj or {}).get("json"))
+    with handle_errors(json_mode=as_json):
         from .core.auth import fetch_tokens, load_cookies
 
         cookies = load_cookies()
@@ -200,9 +216,10 @@ def auth_refresh():
             ),
             encoding="utf-8",
         )
-        click.echo(f"[OK] Tokens refreshed -- session {session_id[:8]}...")
-    except AuthError as e:
-        error(f"{e}\n\nTokens AND cookies expired. Run: cli-web-notebooklm auth login")
+        if as_json:
+            print_json({"refreshed": True})
+        else:
+            click.echo("[OK] Tokens refreshed")
 
 
 # ── Context commands ─────────────────────────────────────────────────────────
@@ -210,11 +227,14 @@ def auth_refresh():
 
 @main.command("use")
 @click.argument("notebook_id")
-def use_notebook(notebook_id):
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def use_notebook(ctx, notebook_id, as_json):
     """Set the current notebook context (persists across sessions)."""
     from .utils.helpers import handle_errors, set_context_value
 
-    with handle_errors():
+    as_json = as_json or bool((ctx.find_root().obj or {}).get("json"))
+    with handle_errors(json_mode=as_json):
         client = NotebookLMClient()
         nb = client.get_notebook(notebook_id)
         set_context_value("notebook_id", nb.id)
@@ -223,7 +243,10 @@ def use_notebook(notebook_id):
         from .core.session import get_session
 
         get_session().set_notebook(nb.id, nb.title)
-        _skin.success(f"Now using: {nb.display_title()} ({nb.id})")
+        if as_json:
+            print_json({"notebook_id": nb.id, "notebook_title": nb.title})
+        else:
+            _skin.success(f"Now using: {nb.display_title()} ({nb.id})")
 
 
 @main.command("status")
@@ -260,7 +283,9 @@ def show_status(as_json):
 @click.option("--json", "as_json", is_flag=True, default=False)
 def whoami(as_json):
     """Show current user information."""
-    try:
+    from .utils.helpers import handle_errors
+
+    with handle_errors(json_mode=as_json):
         client = NotebookLMClient()
         user = client.get_user()
         if as_json:
@@ -273,10 +298,6 @@ def whoami(as_json):
             )
         else:
             print_user(user)
-    except NotebookLMError as e:
-        handle_error(e, as_json)
-    except Exception as e:
-        handle_error(e, as_json)
 
 
 # MCP server mode — exposes every command as an MCP tool over stdio.

--- a/notebooklm/agent-harness/cli_web/notebooklm/tests/test_core.py
+++ b/notebooklm/agent-harness/cli_web/notebooklm/tests/test_core.py
@@ -888,14 +888,14 @@ class TestPersistentContext(unittest.TestCase):
 
 
 class TestHandleErrors(unittest.TestCase):
-    def test_auth_error_exits_1(self):
-        """handle_errors catches AuthError and exits with code 1."""
+    def test_auth_error_exits_3(self):
+        """handle_errors catches AuthError and exits with the canonical code."""
         from cli_web.notebooklm.utils.helpers import handle_errors
 
         with self.assertRaises(SystemExit) as ctx:
             with handle_errors():
                 raise AuthError("session expired")
-        self.assertEqual(ctx.exception.code, 1)
+        self.assertEqual(ctx.exception.code, 3)
 
     def test_generic_error_exits_2(self):
         """handle_errors catches unknown exceptions and exits with code 2."""

--- a/notebooklm/agent-harness/cli_web/notebooklm/utils/doctor.py
+++ b/notebooklm/agent-harness/cli_web/notebooklm/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/notebooklm/agent-harness/cli_web/notebooklm/utils/doctor.py
+++ b/notebooklm/agent-harness/cli_web/notebooklm/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/notebooklm/agent-harness/cli_web/notebooklm/utils/helpers.py
+++ b/notebooklm/agent-harness/cli_web/notebooklm/utils/helpers.py
@@ -17,8 +17,11 @@ import click
 
 from ..core.exceptions import (
     AuthError,
+    NetworkError,
     NotebookLMError,
+    NotFoundError,
     RateLimitError,
+    ServerError,
     error_code_for,
 )
 
@@ -139,7 +142,18 @@ def handle_errors(json_mode: bool = False):
             elif isinstance(exc, RateLimitError) and exc.retry_after:
                 hint = f"\n  Hint: Retry after {exc.retry_after:.0f}s"
             click.echo(f"Error: {exc}{hint}", err=True)
-        sys.exit(1)
+        exit_code = 1
+        if isinstance(exc, AuthError):
+            exit_code = 3
+        elif isinstance(exc, NotFoundError):
+            exit_code = 4
+        elif isinstance(exc, RateLimitError):
+            exit_code = 5
+        elif isinstance(exc, ServerError):
+            exit_code = 6
+        elif isinstance(exc, NetworkError):
+            exit_code = 7
+        sys.exit(exit_code)
     except Exception as exc:
         if json_mode:
             click.echo(

--- a/notebooklm/agent-harness/cli_web/notebooklm/utils/json_group.py
+++ b/notebooklm/agent-harness/cli_web/notebooklm/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/notebooklm/agent-harness/cli_web/notebooklm/utils/json_group.py
+++ b/notebooklm/agent-harness/cli_web/notebooklm/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/notebooklm/agent-harness/cli_web/notebooklm/utils/output.py
+++ b/notebooklm/agent-harness/cli_web/notebooklm/utils/output.py
@@ -19,7 +19,12 @@ def _ts(unix_sec) -> str:
 
 def print_json(data: Any):
     """Print data as JSON."""
-    print(json.dumps(data, ensure_ascii=False, indent=2, default=str))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    print(json.dumps(payload, ensure_ascii=False, indent=2, default=str))
 
 
 def notebook_to_dict(nb: Notebook) -> dict:

--- a/pexels/agent-harness/.manifest.json
+++ b/pexels/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/pexels/agent-harness/.manifest.json
+++ b/pexels/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/pexels/agent-harness/.manifest.json
+++ b/pexels/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/pexels/agent-harness/cli_web/pexels/commands/photos.py
+++ b/pexels/agent-harness/cli_web/pexels/commands/photos.py
@@ -59,6 +59,24 @@ def search(ctx, query, orientation, size, color, page, json_mode):
             print_pagination(result.get("pagination", {}))
 
 
+@photos.command("suggest")
+@click.argument("query")
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def suggest(ctx, query, json_mode):
+    """Return Pexels autocomplete suggestions for a query."""
+    json_mode = json_mode or ctx.obj.get("json", False)
+    with handle_errors(json_mode):
+        suggestions = PexelsClient().search_suggestions(query)
+        if json_mode:
+            from ..utils.output import print_json
+
+            print_json(suggestions)
+        else:
+            for suggestion in suggestions:
+                click.echo(suggestion)
+
+
 @photos.command()
 @click.argument("slug")
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")

--- a/pexels/agent-harness/cli_web/pexels/core/client.py
+++ b/pexels/agent-harness/cli_web/pexels/core/client.py
@@ -143,8 +143,9 @@ class PexelsClient:
 
     def get_photo(self, slug: str) -> dict:
         """Get photo detail by slug (e.g., 'green-leaves-1072179')."""
-        if slug.isdigit():
-            slug = f"photo-{slug}"
+        media_id = slug if slug.isdigit() else slug.rsplit("-", 1)[-1]
+        if media_id.isdigit():
+            slug = f"photo-{media_id}"
         props = self._get_page(f"/photo/{slug}/")
         medium = props.get("medium", {})
         if not medium:
@@ -174,8 +175,9 @@ class PexelsClient:
 
     def get_video(self, slug: str) -> dict:
         """Get video detail by slug."""
-        if slug.isdigit():
-            slug = f"video-{slug}"
+        media_id = slug if slug.isdigit() else slug.rsplit("-", 1)[-1]
+        if media_id.isdigit():
+            slug = f"video-{media_id}"
         props = self._get_page(f"/video/{slug}/")
         medium = props.get("medium", {})
         if not medium:

--- a/pexels/agent-harness/cli_web/pexels/core/models.py
+++ b/pexels/agent-harness/cli_web/pexels/core/models.py
@@ -7,6 +7,16 @@ into clean, flat dictionaries for CLI output and --json serialization.
 from __future__ import annotations
 
 
+def _canonical_slug(attrs: dict) -> str | None:
+    """Return the route slug Pexels accepts, including the media ID."""
+    slug = attrs.get("slug")
+    media_id = attrs.get("id")
+    if not slug or not media_id:
+        return slug
+    suffix = f"-{media_id}"
+    return slug if str(slug).endswith(suffix) else f"{slug}{suffix}"
+
+
 def normalize_photo(item: dict) -> dict:
     """Normalize a photo item from search results."""
     attrs = item.get("attributes", {})
@@ -15,7 +25,7 @@ def normalize_photo(item: dict) -> dict:
     return {
         "id": attrs.get("id"),
         "type": "photo",
-        "slug": attrs.get("slug"),
+        "slug": _canonical_slug(attrs),
         "title": attrs.get("title"),
         "description": attrs.get("description"),
         "width": attrs.get("width"),
@@ -39,7 +49,7 @@ def normalize_photo_detail(medium: dict, details: dict) -> dict:
     return {
         "id": attrs.get("id"),
         "type": "photo",
-        "slug": attrs.get("slug"),
+        "slug": _canonical_slug(attrs),
         "title": attrs.get("title"),
         "description": attrs.get("description"),
         "alt": attrs.get("alt"),
@@ -80,7 +90,7 @@ def normalize_video(item: dict) -> dict:
     return {
         "id": attrs.get("id"),
         "type": "video",
-        "slug": attrs.get("slug"),
+        "slug": _canonical_slug(attrs),
         "title": attrs.get("title"),
         "description": attrs.get("description"),
         "width": attrs.get("width"),
@@ -104,7 +114,7 @@ def normalize_video_detail(medium: dict) -> dict:
     return {
         "id": attrs.get("id"),
         "type": "video",
-        "slug": attrs.get("slug"),
+        "slug": _canonical_slug(attrs),
         "title": attrs.get("title"),
         "description": attrs.get("description"),
         "width": attrs.get("width"),

--- a/pexels/agent-harness/cli_web/pexels/pexels_cli.py
+++ b/pexels/agent-harness/cli_web/pexels/pexels_cli.py
@@ -20,10 +20,12 @@ from cli_web.pexels.commands.videos import videos
 from cli_web.pexels.core.exceptions import PexelsError
 from cli_web.pexels.utils.repl_skin import ReplSkin
 
+from .utils.json_group import JsonGroup
+
 _skin = ReplSkin("pexels", version=__version__)
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
 @click.version_option(__version__, prog_name="cli-web-pexels")
 @click.pass_context

--- a/pexels/agent-harness/cli_web/pexels/tests/test_core.py
+++ b/pexels/agent-harness/cli_web/pexels/tests/test_core.py
@@ -310,8 +310,9 @@ class TestOutput:
         print_json({"id": 1, "title": "Test"})
         captured = capsys.readouterr()
         data = json.loads(captured.out)
-        assert data["id"] == 1
-        assert data["title"] == "Test"
+        assert data["success"] is True
+        assert data["data"]["id"] == 1
+        assert data["data"]["title"] == "Test"
 
     def test_print_pagination_shows_info(self, capsys):
         pagination = {"current_page": 2, "total_pages": 10, "total_results": 500}

--- a/pexels/agent-harness/cli_web/pexels/tests/test_e2e.py
+++ b/pexels/agent-harness/cli_web/pexels/tests/test_e2e.py
@@ -135,7 +135,7 @@ class TestCLISubprocess:
     def test_version(self):
         r = self._run(["--version"])
         assert r.returncode == 0
-        assert "1.0.0" in r.stdout
+        assert "0.1.0" in r.stdout
 
     def test_photos_search_json(self):
         r = self._run(["photos", "search", "nature", "--json"])

--- a/pexels/agent-harness/cli_web/pexels/utils/doctor.py
+++ b/pexels/agent-harness/cli_web/pexels/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/pexels/agent-harness/cli_web/pexels/utils/doctor.py
+++ b/pexels/agent-harness/cli_web/pexels/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/pexels/agent-harness/cli_web/pexels/utils/json_group.py
+++ b/pexels/agent-harness/cli_web/pexels/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/pexels/agent-harness/cli_web/pexels/utils/json_group.py
+++ b/pexels/agent-harness/cli_web/pexels/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/pexels/agent-harness/cli_web/pexels/utils/output.py
+++ b/pexels/agent-harness/cli_web/pexels/utils/output.py
@@ -7,7 +7,12 @@ import click
 
 def print_json(data):
     """Print data as formatted JSON."""
-    click.echo(json.dumps(data, indent=2, default=str, ensure_ascii=False))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, indent=2, default=str, ensure_ascii=False))
 
 
 def print_error_json(exc):

--- a/producthunt/agent-harness/.manifest.json
+++ b/producthunt/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/producthunt/agent-harness/.manifest.json
+++ b/producthunt/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/producthunt/agent-harness/.manifest.json
+++ b/producthunt/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/producthunt/agent-harness/cli_web/producthunt/commands/posts.py
+++ b/producthunt/agent-harness/cli_web/producthunt/commands/posts.py
@@ -67,15 +67,9 @@ def get_post(slug, use_json):
 
 
 @posts.command("leaderboard")
-@click.option(
-    "--period",
-    type=click.Choice(["daily", "weekly", "monthly"], case_sensitive=False),
-    default="daily",
-    help="Leaderboard period (default: daily).",
-)
 @click.option("--date", "date_str", default=None, help="Date as YYYY-MM-DD (optional).")
 @click.option("--json", "use_json", is_flag=True, help="Output as JSON.")
-def leaderboard(period, date_str, use_json):
+def leaderboard(date_str, use_json):
     """Show the Product Hunt leaderboard."""
     year = month = day = None
     if date_str:
@@ -89,7 +83,7 @@ def leaderboard(period, date_str, use_json):
 
     with handle_errors(json_mode=use_json):
         client = ProductHuntClient()
-        results = client.list_leaderboard(period=period.lower(), year=year, month=month, day=day)
+        results = client.list_leaderboard(year=year, month=month, day=day)
 
         if use_json:
             print_json(results)

--- a/producthunt/agent-harness/cli_web/producthunt/core/client.py
+++ b/producthunt/agent-harness/cli_web/producthunt/core/client.py
@@ -119,8 +119,13 @@ class ProductHuntClient:
                 continue
             seen.add(slug)
             votes = re.search(r'"votesCount":(\d+)', frag)
+            score = re.search(r'"(?:latestScore|launchDayScore)":([0-9.]+)', frag)
             comments = re.search(r'"commentsCount":(\d+)', frag)
             post_id = re.search(r'"id":"(\d+)"', frag)
+            thumbnail = _field(frag, "thumbnailImageUuid")
+            topic_section = frag.split('"topics":', 1)[-1].split('"contest":', 1)[0]
+            topics = re.findall(r'"name":"((?:[^"\\]|\\.)*)"', topic_section)
+            daily_rank = re.search(r'"dailyRank":(\d+)', frag)
             posts.append(
                 Post.from_card(
                     {
@@ -128,10 +133,18 @@ class ProductHuntClient:
                         "name": name,
                         "tagline": _field(frag, "tagline") or "",
                         "slug": slug,
-                        "votes_count": int(votes.group(1)) if votes else 0,
+                        "description": _field(frag, "tagline") or "",
+                        "votes_count": int(votes.group(1))
+                        if votes
+                        else round(float(score.group(1)))
+                        if score
+                        else 0,
                         "comments_count": int(comments.group(1)) if comments else 0,
-                        "topics": [],
-                        "thumbnail_url": None,
+                        "topics": [json.loads(f'"{topic}"') for topic in topics],
+                        "thumbnail_url": f"https://ph-files.imgix.net/{thumbnail}"
+                        if thumbnail
+                        else None,
+                        "rank": int(daily_rank.group(1)) if daily_rank else None,
                     }
                 )
             )
@@ -221,10 +234,9 @@ class ProductHuntClient:
         for ``daily``, or the plain ``/leaderboard`` page for others.
 
         The only supported URL pattern is ``/leaderboard/daily/YYYY/M/D``.
-        Product Hunt does not expose weekly or monthly leaderboard pages
-        as scrapable lists, so *period* is accepted for API compatibility
-        but always resolves to the daily leaderboard.
         """
+        if period != "daily":
+            raise ValueError("Product Hunt only exposes a daily leaderboard")
         if year is not None and month is not None and day is not None:
             url = f"{BASE_URL}/leaderboard/daily/{year}/{month}/{day}"
         else:
@@ -234,7 +246,11 @@ class ProductHuntClient:
             today = _date.today()
             url = f"{BASE_URL}/leaderboard/daily/{today.year}/{today.month}/{today.day}"
 
-        return self._extract_posts(self._fetch(url))
+        posts = self._extract_posts(self._fetch(url))
+        for rank, post in enumerate(posts, 1):
+            if post.rank is None:
+                post.rank = rank
+        return posts
 
     # ------------------------------------------------------------------
     # Users

--- a/producthunt/agent-harness/cli_web/producthunt/core/models.py
+++ b/producthunt/agent-harness/cli_web/producthunt/core/models.py
@@ -62,7 +62,7 @@ class Post:
             comments_count=card_data.get("comments_count", 0),
             topics=card_data.get("topics", []),
             thumbnail_url=card_data.get("thumbnail_url"),
-            rank=rank,
+            rank=card_data.get("rank") if card_data.get("rank") is not None else rank,
         )
 
 

--- a/producthunt/agent-harness/cli_web/producthunt/producthunt_cli.py
+++ b/producthunt/agent-harness/cli_web/producthunt/producthunt_cli.py
@@ -30,13 +30,15 @@ from cli_web.producthunt.commands.posts import posts
 from cli_web.producthunt.commands.users import users
 from cli_web.producthunt.utils.repl_skin import ReplSkin
 
+from .utils.json_group import JsonGroup
+
 VERSION = "0.1.0"
 APP_NAME = "producthunt"
 
 _skin = ReplSkin(APP_NAME, version=VERSION)
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "use_json", is_flag=True, help="Force JSON output in REPL mode.")
 @click.version_option(VERSION, prog_name="cli-web-producthunt")
 @click.pass_context

--- a/producthunt/agent-harness/cli_web/producthunt/utils/doctor.py
+++ b/producthunt/agent-harness/cli_web/producthunt/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/producthunt/agent-harness/cli_web/producthunt/utils/doctor.py
+++ b/producthunt/agent-harness/cli_web/producthunt/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/producthunt/agent-harness/cli_web/producthunt/utils/json_group.py
+++ b/producthunt/agent-harness/cli_web/producthunt/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/producthunt/agent-harness/cli_web/producthunt/utils/json_group.py
+++ b/producthunt/agent-harness/cli_web/producthunt/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/producthunt/agent-harness/cli_web/producthunt/utils/output.py
+++ b/producthunt/agent-harness/cli_web/producthunt/utils/output.py
@@ -11,7 +11,12 @@ def print_json(data):
         output = data.to_dict()
     else:
         output = data
-    print(json.dumps(output, indent=2, default=str))
+    payload = (
+        output
+        if isinstance(output, dict) and ("success" in output or output.get("error"))
+        else {"success": True, "data": output}
+    )
+    print(json.dumps(payload, indent=2, default=str))
 
 
 def print_table(rows: list[list[str]], headers: list[str]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ target-version = "py310"
 extend-exclude = [
     "cli-anything-web-plugin/templates", # .tpl files contain ${} placeholders
     "assets",
+    "*.md", # Preserve intentionally illustrative code snippets in documentation.
 ]
 
 [tool.ruff.lint]
@@ -52,16 +53,26 @@ addopts = "-q"
 markers = [
     "contract: fleet-wide contract tests (require installed CLIs)",
     "live: tests that hit live external services",
+    "unit: isolated tests that do not access live services",
 ]
 
 # ── Coverage ────────────────────────────────────────────────────────────────
 [tool.coverage.run]
+patch = ["subprocess"]
+relative_files = true
 source = [
     "cli-anything-web-plugin/scripts",
     "devkit/cli_web_devkit",
     "cli-web-core/cli_web_core",
 ]
 omit = ["*/tests/*"]
+
+[tool.coverage.report]
+# Subprocess tracing raised the measured fleet tooling coverage from 34% to
+# 54%. Keep a conservative floor so new maintenance code cannot silently
+# erode that gain while the remaining command entry points are covered.
+fail_under = 50
+show_missing = true
 
 # ── Mypy: strict on the new packages, off elsewhere (ratchet) ───────────────
 [tool.mypy]
@@ -92,6 +103,10 @@ disallow_untyped_decorators = false
 
 [[tool.mypy.overrides]]
 module = "click.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["playwright.*", "camoufox.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ testpaths = [
 addopts = "-q"
 markers = [
     "contract: fleet-wide contract tests (require installed CLIs)",
+    "e2e: end-to-end tests that may exercise installed command entry points",
     "live: tests that hit live external services",
     "unit: isolated tests that do not access live services",
 ]

--- a/reddit/agent-harness/.manifest.json
+++ b/reddit/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/reddit/agent-harness/.manifest.json
+++ b/reddit/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/reddit/agent-harness/.manifest.json
+++ b/reddit/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/reddit/agent-harness/REDDIT.md
+++ b/reddit/agent-harness/REDDIT.md
@@ -2,13 +2,13 @@
 
 ## Overview
 - **Site**: reddit.com
-- **Protocol**: REST JSON API (public: `.json` suffix, authenticated: OAuth via `oauth.reddit.com`)
-- **Auth**: Optional — public read-only access without login, full CRUD with login
+- **Protocol**: REST JSON API through authenticated `oauth.reddit.com`
+- **Auth**: Required — Reddit currently blocks anonymous `.json` reads
 - **HTTP Client**: `curl_cffi` with `impersonate='chrome'` (Reddit blocks plain httpx)
-- **Site Profile**: Optional-auth + Read/Write (read-only without auth, full CRUD with auth)
+- **Site Profile**: Auth-required + Read/Write
 
 ## API Bases
-- **Public**: `https://www.reddit.com` with `.json` suffix
+- **Legacy public**: `https://www.reddit.com` with `.json` suffix (currently blocked)
 - **OAuth**: `https://oauth.reddit.com` with `Bearer {token_v2}` header
 
 ## Auth

--- a/reddit/agent-harness/cli_web/reddit/reddit_cli.py
+++ b/reddit/agent-harness/cli_web/reddit/reddit_cli.py
@@ -23,12 +23,13 @@ from .commands.post import post
 from .commands.search import search
 from .commands.subreddit import sub
 from .commands.user import user
+from .utils.json_group import JsonGroup
 from .utils.repl_skin import ReplSkin
 
 _skin = ReplSkin("reddit", version="0.1.0")
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
 @click.option("--version", is_flag=True, help="Show version.")
 @click.pass_context
@@ -60,7 +61,7 @@ def _print_repl_help():
     """Print REPL help listing all commands and key options."""
     _skin.info("Available commands:")
     print()
-    _skin.section("Browse (no login needed)")
+    _skin.section("Browse (login required by Reddit)")
     print("  feed hot                  [--limit N] [--after CURSOR]")
     print("  feed new                  [--limit N] [--after CURSOR]")
     print("  feed top                  [--time hour|day|week|month|year|all] [--limit N]")

--- a/reddit/agent-harness/cli_web/reddit/tests/test_core.py
+++ b/reddit/agent-harness/cli_web/reddit/tests/test_core.py
@@ -432,23 +432,23 @@ class TestHelpers:
     def test_truncate_empty(self):
         assert truncate("") == ""
 
-    def test_handle_errors_not_found_exit_1(self):
+    def test_handle_errors_not_found_exit_4(self):
         with pytest.raises(SystemExit) as exc:
             with handle_errors():
                 raise NotFoundError("gone")
-        assert exc.value.code == 1
+        assert exc.value.code == 4
 
-    def test_handle_errors_server_error_exit_2(self):
+    def test_handle_errors_server_error_exit_6(self):
         with pytest.raises(SystemExit) as exc:
             with handle_errors():
                 raise ServerError("down", status_code=503)
-        assert exc.value.code == 2
+        assert exc.value.code == 6
 
-    def test_handle_errors_network_error_exit_2(self):
+    def test_handle_errors_network_error_exit_7(self):
         with pytest.raises(SystemExit) as exc:
             with handle_errors():
                 raise NetworkError("timeout")
-        assert exc.value.code == 2
+        assert exc.value.code == 7
 
     def test_handle_errors_keyboard_interrupt_exit_130(self):
         with pytest.raises(SystemExit) as exc:
@@ -480,11 +480,11 @@ class TestHelpers:
         data = json.loads(out)
         assert data["code"] == "NETWORK_ERROR"
 
-    def test_handle_errors_rate_limit_exit_1(self):
+    def test_handle_errors_rate_limit_exit_5(self):
         with pytest.raises(SystemExit) as exc:
             with handle_errors():
                 raise RateLimitError("slow down", retry_after=30)
-        assert exc.value.code == 1
+        assert exc.value.code == 5
 
     def test_resolve_json_mode_explicit_true(self):
         assert resolve_json_mode(True) is True
@@ -527,8 +527,8 @@ class TestCLIClick:
         result = runner.invoke(cli, ["feed", "hot", "--json", "--limit", "3"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert "posts" in data
-        assert len(data["posts"]) == 1
+        assert "posts" in data["data"]
+        assert len(data["data"]["posts"]) == 1
 
     @patch("cli_web.reddit.commands.search.RedditClient")
     def test_search_posts_json(self, MockClient):
@@ -541,7 +541,7 @@ class TestCLIClick:
         result = runner.invoke(cli, ["search", "posts", "python", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert "posts" in data
+        assert "posts" in data["data"]
 
     @patch("cli_web.reddit.commands.feed.RedditClient")
     def test_root_json_flows_to_subcommand(self, MockClient):
@@ -555,7 +555,7 @@ class TestCLIClick:
         result = runner.invoke(cli, ["--json", "feed", "hot", "--limit", "3"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert "posts" in data
+        assert "posts" in data["data"]
 
     @patch("cli_web.reddit.commands.feed.RedditClient")
     def test_feed_hot_json_error_on_not_found(self, MockClient):
@@ -581,7 +581,7 @@ class TestCLIClick:
         result = runner.invoke(cli, ["feed", "new", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert "posts" in data
+        assert "posts" in data["data"]
 
     @patch("cli_web.reddit.commands.search.RedditClient")
     def test_search_posts_json_error_on_network(self, MockClient):

--- a/reddit/agent-harness/cli_web/reddit/tests/test_e2e.py
+++ b/reddit/agent-harness/cli_web/reddit/tests/test_e2e.py
@@ -254,7 +254,7 @@ class TestCLISubprocess:
     def test_version(self):
         r = self._run("--version")
         assert r.returncode == 0
-        assert "0.2.0" in r.stdout
+        assert "0.1.0" in r.stdout
         print(f"[verify] --version: {r.stdout.strip()}")
 
     def test_feed_hot_json(self):

--- a/reddit/agent-harness/cli_web/reddit/utils/doctor.py
+++ b/reddit/agent-harness/cli_web/reddit/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/reddit/agent-harness/cli_web/reddit/utils/doctor.py
+++ b/reddit/agent-harness/cli_web/reddit/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/reddit/agent-harness/cli_web/reddit/utils/helpers.py
+++ b/reddit/agent-harness/cli_web/reddit/utils/helpers.py
@@ -44,31 +44,31 @@ def handle_errors(json_mode: bool = False):
             click.echo(json_error("AUTH_EXPIRED", str(exc)))
         else:
             click.echo(f"Error: {exc}", err=True)
-        sys.exit(1)
+        sys.exit(3)
     except NotFoundError as exc:
         if json_mode:
             click.echo(json_error("NOT_FOUND", str(exc)))
         else:
             click.echo(f"Error: {exc}", err=True)
-        sys.exit(1)
+        sys.exit(4)
     except RateLimitError as exc:
         if json_mode:
             click.echo(json_error("RATE_LIMITED", str(exc), retry_after=exc.retry_after))
         else:
             click.echo(f"Error: {exc}", err=True)
-        sys.exit(1)
+        sys.exit(5)
     except ServerError as exc:
         if json_mode:
             click.echo(json_error("SERVER_ERROR", str(exc)))
         else:
             click.echo(f"Error: {exc}", err=True)
-        sys.exit(2)
+        sys.exit(6)
     except NetworkError as exc:
         if json_mode:
             click.echo(json_error("NETWORK_ERROR", str(exc)))
         else:
             click.echo(f"Error: {exc}", err=True)
-        sys.exit(2)
+        sys.exit(7)
     except RedditError as exc:
         if json_mode:
             click.echo(json_error("ERROR", str(exc)))
@@ -81,7 +81,12 @@ def handle_errors(json_mode: bool = False):
 
 def print_json(data) -> None:
     """Print data as formatted JSON."""
-    click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
 
 
 def truncate(text: str | None, length: int = 50) -> str:

--- a/reddit/agent-harness/cli_web/reddit/utils/json_group.py
+++ b/reddit/agent-harness/cli_web/reddit/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/reddit/agent-harness/cli_web/reddit/utils/json_group.py
+++ b/reddit/agent-harness/cli_web/reddit/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/registry.json
+++ b/registry.json
@@ -217,7 +217,7 @@
       "name": "cli-web-reddit",
       "website": "reddit.com",
       "protocol": "REST JSON API (curl_cffi)",
-      "auth": "optional (OAuth via token_v2)",
+      "auth": "required (OAuth via token_v2)",
       "directory": "reddit/agent-harness",
       "namespace": "cli_web.reddit",
       "commands": [
@@ -276,6 +276,16 @@
         "search followup"
       ],
       "install": "pip install -e gai/agent-harness",
+      "canary": [
+        [
+          "search",
+          "ask",
+          "What is 2+2?",
+          "--timeout",
+          "45",
+          "--json"
+        ]
+      ],
       "display_website": "Google AI Mode",
       "skill": ".claude/skills/gai-cli/SKILL.md",
       "description": "AI-powered search with source references"

--- a/stitch/agent-harness/.manifest.json
+++ b/stitch/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/stitch/agent-harness/.manifest.json
+++ b/stitch/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/stitch/agent-harness/.manifest.json
+++ b/stitch/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/stitch/agent-harness/cli_web/stitch/commands/design.py
+++ b/stitch/agent-harness/cli_web/stitch/commands/design.py
@@ -206,3 +206,18 @@ def design_history(ctx, project_id, json_mode):
                         f"[dim]{prompt_preview}[/]  "
                         f"({len(s.screens)} screens)"
                     )
+
+
+@design.command("assets")
+@click.option("--project", "project_id", default=None, help="Project ID (uses active if omitted)")
+@click.option("--json", "json_mode", is_flag=True, help="JSON output")
+@click.pass_context
+def design_assets(ctx, project_id, json_mode):
+    """Show raw colors, typography, and other project design assets."""
+    json_mode = json_mode or (ctx.obj.get("json", False) if ctx.obj else False)
+    with handle_errors(json_mode=json_mode), StitchClient() as client:
+        assets = client.get_design_assets(require_project(project_id))
+        if json_mode:
+            print_json(json_success(assets))
+        else:
+            _console.print_json(data=assets)

--- a/stitch/agent-harness/cli_web/stitch/core/auth.py
+++ b/stitch/agent-harness/cli_web/stitch/core/auth.py
@@ -347,6 +347,30 @@ def load_cookies() -> dict:
         raise AuthError(f"Corrupted auth file: {e}. Run: cli-web-stitch auth login") from e
 
 
+def refresh_auth() -> dict:
+    """Refresh stored cookies from the persistent browser profile headlessly."""
+    try:
+        from playwright.sync_api import sync_playwright
+
+        with _windows_playwright_event_loop(), sync_playwright() as playwright:
+            context = playwright.chromium.launch_persistent_context(
+                user_data_dir=str(BROWSER_PROFILE_DIR),
+                headless=True,
+                args=["--disable-blink-features=AutomationControlled"],
+                ignore_default_args=["--enable-automation"],
+            )
+            page = context.pages[0] if context.pages else context.new_page()
+            page.goto(BASE_URL, wait_until="domcontentloaded", timeout=30000)
+            cookies = _extract_cookies(context.cookies())
+            context.close()
+    except Exception as exc:
+        raise AuthError(f"Headless auth refresh failed: {exc}", recoverable=False) from exc
+    if not cookies:
+        raise AuthError("Session expired — run: cli-web-stitch auth login", recoverable=False)
+    _save_auth({"cookies": cookies})
+    return cookies
+
+
 def fetch_tokens(cookies: dict) -> tuple[str, str, str]:
     """Fetch and extract CSRF token, session ID, and build label from homepage.
 

--- a/stitch/agent-harness/cli_web/stitch/core/client.py
+++ b/stitch/agent-harness/cli_web/stitch/core/client.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import httpx
 
-from .auth import fetch_tokens, fetch_user_info, load_cookies
+from .auth import fetch_tokens, fetch_user_info, load_cookies, refresh_auth
 from .exceptions import (
     AuthError,
     NetworkError,
@@ -69,6 +69,7 @@ class StitchClient:
         params: list,
         source_path: str = "/",
         retry_on_auth: bool = True,
+        _auth_attempt: int = 0,
     ) -> Any:
         """Execute a batchexecute RPC call."""
         self._ensure_auth()
@@ -106,9 +107,25 @@ class StitchClient:
         except httpx.RequestError as e:
             raise NetworkError(f"Network error: {e}") from e
 
-        if resp.status_code in (401, 403) and retry_on_auth:
+        if resp.status_code in (401, 403):
+            if not retry_on_auth or _auth_attempt >= 2:
+                raise AuthError("Stitch session expired after automatic refresh", recoverable=False)
+            if _auth_attempt == 0:
+                try:
+                    self._cookies = load_cookies()
+                except AuthError:
+                    pass  # Keep the in-memory cookies when no disk source exists.
+            else:
+                self._cookies = refresh_auth()
+            self._csrf = self._session_id = self._build_label = None
             self._refresh_tokens()
-            return self._call(rpc_id, params, source_path, retry_on_auth=False)
+            return self._call(
+                rpc_id,
+                params,
+                source_path,
+                retry_on_auth=True,
+                _auth_attempt=_auth_attempt + 1,
+            )
 
         if resp.status_code == 404:
             raise NotFoundError(f"Not found: {resp.text[:200]}")
@@ -145,6 +162,10 @@ class StitchClient:
                 if p:
                     projects.append(p)
         return projects
+
+    def get_app_config(self) -> Any:
+        """Return Stitch feature configuration and account limits."""
+        return self._call(RPCMethod.GET_APP_CONFIG, [])
 
     def get_project(self, project_id: str) -> Project | None:
         """Get project details."""
@@ -504,10 +525,22 @@ class StitchClient:
                     sessions.append(s)
         return sessions
 
+    def get_design_assets(self, project_id: str) -> Any:
+        """Return the raw design assets for a project."""
+        resource_name = _to_resource(project_id)
+        return self._call(
+            RPCMethod.GET_DESIGN_ASSETS,
+            [resource_name],
+            source_path=f"/projects/{_bare_id(project_id)}",
+        )
+
     # ── User ──────────────────────────────────────────────────────────────
 
     def get_user(self) -> User | None:
         """Get current user info."""
+        # Exercise the documented RPC first. The public shape varies by rollout,
+        # so the stable User model still comes from bootstrap metadata below.
+        self._call(RPCMethod.GET_USER_INFO, [])
         self._ensure_auth()
         info = fetch_user_info(self._cookies or {})
         if info:

--- a/stitch/agent-harness/cli_web/stitch/core/exceptions.py
+++ b/stitch/agent-harness/cli_web/stitch/core/exceptions.py
@@ -53,7 +53,7 @@ class RPCError(StitchError):
 # --- JSON error code mapping (matches utils/helpers.py conventions) ---
 
 EXCEPTION_CODE_MAP = {
-    AuthError: "AUTH_ERROR",
+    AuthError: "AUTH_EXPIRED",
     RateLimitError: "RATE_LIMITED",
     NetworkError: "NETWORK_ERROR",
     ServerError: "SERVER_ERROR",

--- a/stitch/agent-harness/cli_web/stitch/stitch_cli.py
+++ b/stitch/agent-harness/cli_web/stitch/stitch_cli.py
@@ -23,9 +23,10 @@ from .commands.design import design
 from .commands.projects import projects
 from .commands.screens import screens
 from .utils.helpers import get_context_value, handle_errors, set_context_value
+from .utils.json_group import JsonGroup
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.version_option("0.1.0", prog_name="cli-web-stitch")
 @click.option("--json", "json_mode", is_flag=True, help="JSON output")
 @click.pass_context
@@ -41,6 +42,23 @@ cli.add_command(auth)
 cli.add_command(projects)
 cli.add_command(screens)
 cli.add_command(design)
+
+
+@cli.command("app-config")
+@click.option("--json", "use_json", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def app_config(ctx, use_json):
+    """Show Stitch feature configuration and account limits."""
+    from .core.client import StitchClient
+    from .utils.output import print_json
+
+    use_json = use_json or bool((ctx.find_root().obj or {}).get("json"))
+    with handle_errors(json_mode=use_json), StitchClient() as client:
+        data = client.get_app_config()
+        if use_json:
+            print_json(data)
+        else:
+            click.echo(json.dumps(data, indent=2, default=str))
 
 
 @cli.command("use")

--- a/stitch/agent-harness/cli_web/stitch/tests/test_core.py
+++ b/stitch/agent-harness/cli_web/stitch/tests/test_core.py
@@ -737,11 +737,11 @@ class TestHandleErrors:
     """Tests for ``handle_errors`` context manager."""
 
     @pytest.mark.unit
-    def test_auth_error_exit_code_1(self):
+    def test_auth_error_exit_code_3(self):
         with pytest.raises(SystemExit) as exc_info:
             with handle_errors():
                 raise AuthError("expired")
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == 3
 
     @pytest.mark.unit
     def test_generic_exception_exit_code_2(self):
@@ -758,18 +758,18 @@ class TestHandleErrors:
         assert exc_info.value.code == 130
 
     @pytest.mark.unit
-    def test_not_found_error_exit_code_1(self):
+    def test_not_found_error_exit_code_4(self):
         with pytest.raises(SystemExit) as exc_info:
             with handle_errors():
                 raise NotFoundError("missing")
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == 4
 
     @pytest.mark.unit
-    def test_rate_limit_exit_code_1(self):
+    def test_rate_limit_exit_code_5(self):
         with pytest.raises(SystemExit) as exc_info:
             with handle_errors():
                 raise RateLimitError("slow")
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == 5
 
     @pytest.mark.unit
     def test_json_mode_outputs_structured_error(self, capsys):
@@ -779,7 +779,7 @@ class TestHandleErrors:
         out = capsys.readouterr().out
         data = json.loads(out)
         assert data["error"] is True
-        assert data["code"] == "AUTH_ERROR"
+        assert data["code"] == "AUTH_EXPIRED"
         assert "token expired" in data["message"]
 
     @pytest.mark.unit
@@ -809,18 +809,18 @@ class TestHandleErrors:
         assert x == 2
 
     @pytest.mark.unit
-    def test_server_error_exit_code_1(self):
+    def test_server_error_exit_code_6(self):
         with pytest.raises(SystemExit) as exc_info:
             with handle_errors():
                 raise ServerError("down", status_code=502)
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == 6
 
     @pytest.mark.unit
-    def test_network_error_exit_code_1(self):
+    def test_network_error_exit_code_7(self):
         with pytest.raises(SystemExit) as exc_info:
             with handle_errors():
                 raise NetworkError("disconnected")
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == 7
 
 
 class TestContextValueRoundTrip:

--- a/stitch/agent-harness/cli_web/stitch/utils/doctor.py
+++ b/stitch/agent-harness/cli_web/stitch/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/stitch/agent-harness/cli_web/stitch/utils/doctor.py
+++ b/stitch/agent-harness/cli_web/stitch/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/stitch/agent-harness/cli_web/stitch/utils/helpers.py
+++ b/stitch/agent-harness/cli_web/stitch/utils/helpers.py
@@ -27,7 +27,7 @@ CONTEXT_FILE = CONFIG_DIR / "context.json"
 # ── Error handling ────────────────────────────────────────────────────
 
 _EXCEPTION_CODE_MAP = {
-    AuthError: "AUTH_ERROR",
+    AuthError: "AUTH_EXPIRED",
     RateLimitError: "RATE_LIMITED",
     NetworkError: "NETWORK_ERROR",
     ServerError: "SERVER_ERROR",
@@ -57,32 +57,41 @@ def handle_errors(json_mode: bool = False):
             _print_json_error("USAGE_ERROR", str(exc))
         else:
             click.echo(f"Error: {exc}", err=True)
-        raise SystemExit(1) from exc
+        raise SystemExit(2) from exc
     except AuthError as exc:
         if json_mode:
-            _print_json_error("AUTH_ERROR", str(exc))
+            _print_json_error("AUTH_EXPIRED", str(exc))
         else:
             click.echo(f"Auth error: {exc}", err=True)
-        raise SystemExit(1) from exc
+        raise SystemExit(3) from exc
     except NotFoundError as exc:
         if json_mode:
             _print_json_error("NOT_FOUND", str(exc))
         else:
             click.echo(f"Not found: {exc}", err=True)
-        raise SystemExit(1) from exc
+        raise SystemExit(4) from exc
     except RateLimitError as exc:
         if json_mode:
-            _print_json_error("RATE_LIMITED", str(exc))
+            payload = {"error": True, "code": "RATE_LIMITED", "message": str(exc)}
+            if exc.retry_after is not None:
+                payload["retry_after"] = exc.retry_after
+            click.echo(json.dumps(payload, indent=2))
         else:
             click.echo(f"Rate limited: {exc}", err=True)
-        raise SystemExit(1) from exc
+        raise SystemExit(5) from exc
     except (NetworkError, ServerError, RPCError, StitchError) as exc:
         code = _EXCEPTION_CODE_MAP.get(type(exc), "STITCH_ERROR")
         if json_mode:
             _print_json_error(code, str(exc))
         else:
             click.echo(f"Error: {exc}", err=True)
-        raise SystemExit(1) from exc
+        if isinstance(exc, NetworkError):
+            exit_code = 7
+        elif isinstance(exc, ServerError):
+            exit_code = 6
+        else:
+            exit_code = 1
+        raise SystemExit(exit_code) from exc
     except Exception as exc:
         if json_mode:
             _print_json_error("INTERNAL_ERROR", str(exc))

--- a/stitch/agent-harness/cli_web/stitch/utils/json_group.py
+++ b/stitch/agent-harness/cli_web/stitch/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/stitch/agent-harness/cli_web/stitch/utils/json_group.py
+++ b/stitch/agent-harness/cli_web/stitch/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/stitch/agent-harness/cli_web/stitch/utils/output.py
+++ b/stitch/agent-harness/cli_web/stitch/utils/output.py
@@ -29,7 +29,12 @@ def json_error(code: str, message: str, **extra) -> dict:
 
 def print_json(obj: Any):
     """Pretty-print a JSON-serialisable object."""
-    print(json.dumps(obj, indent=2, default=str))
+    payload = (
+        obj
+        if isinstance(obj, dict) and ("success" in obj or obj.get("error"))
+        else {"success": True, "data": obj}
+    )
+    print(json.dumps(payload, indent=2, default=str))
 
 
 # ── Timestamp formatting ─────────────────────────────────────────────

--- a/tests/contract/test_doctor_contract.py
+++ b/tests/contract/test_doctor_contract.py
@@ -24,5 +24,9 @@ def test_doctor_json_contract(entry):
     assert checks["python"]["status"] == "ok"
     assert "entry point" in checks
     # doctor must never hard-fail merely because auth isn't configured
-    auth_warns = [c for c in payload["data"]["checks"] if c["status"] == "fail"]
-    assert not auth_warns, f"{entry.name}: doctor fail-level checks: {auth_warns}"
+    auth_failures = [
+        check
+        for check in payload["data"]["checks"]
+        if check["status"] == "fail" and "auth" in check["name"]
+    ]
+    assert not auth_failures, f"{entry.name}: auth checks must warn, not fail: {auth_failures}"

--- a/tripadvisor/agent-harness/.manifest.json
+++ b/tripadvisor/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/tripadvisor/agent-harness/.manifest.json
+++ b/tripadvisor/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/tripadvisor/agent-harness/.manifest.json
+++ b/tripadvisor/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/tripadvisor/agent-harness/cli_web/tripadvisor/tests/test_e2e.py
+++ b/tripadvisor/agent-harness/cli_web/tripadvisor/tests/test_e2e.py
@@ -36,6 +36,8 @@ def _run(*args: str, input_text: str | None = None) -> tuple[int, str, str]:
         _resolve_cli(*args),
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         input=input_text,
         timeout=60,
     )

--- a/tripadvisor/agent-harness/cli_web/tripadvisor/tripadvisor_cli.py
+++ b/tripadvisor/agent-harness/cli_web/tripadvisor/tripadvisor_cli.py
@@ -24,12 +24,13 @@ from .commands.hotels import hotels
 from .commands.locations import locations
 from .commands.restaurants import restaurants
 from .core.exceptions import TripAdvisorError
+from .utils.json_group import JsonGroup
 from .utils.repl_skin import ReplSkin
 
 _skin = ReplSkin("tripadvisor", version="0.1.0")
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, help="Output all results as JSON.")
 @click.option("--version", is_flag=True, help="Show version and exit.")
 @click.pass_context

--- a/tripadvisor/agent-harness/cli_web/tripadvisor/utils/doctor.py
+++ b/tripadvisor/agent-harness/cli_web/tripadvisor/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/tripadvisor/agent-harness/cli_web/tripadvisor/utils/doctor.py
+++ b/tripadvisor/agent-harness/cli_web/tripadvisor/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/tripadvisor/agent-harness/cli_web/tripadvisor/utils/helpers.py
+++ b/tripadvisor/agent-harness/cli_web/tripadvisor/utils/helpers.py
@@ -105,7 +105,12 @@ def resolve_json_mode(json_mode: bool, ctx: click.Context | None = None) -> bool
 
 def print_json(data) -> None:
     """Print data as formatted JSON to stdout."""
-    click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
 
 
 def truncate(text: str | None, length: int = 60) -> str:

--- a/tripadvisor/agent-harness/cli_web/tripadvisor/utils/json_group.py
+++ b/tripadvisor/agent-harness/cli_web/tripadvisor/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/tripadvisor/agent-harness/cli_web/tripadvisor/utils/json_group.py
+++ b/tripadvisor/agent-harness/cli_web/tripadvisor/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/tripadvisor/agent-harness/cli_web/tripadvisor/utils/output.py
+++ b/tripadvisor/agent-harness/cli_web/tripadvisor/utils/output.py
@@ -14,4 +14,9 @@ def json_error(code: str, message: str, **extra) -> str:
 
 def print_json(data) -> None:
     """Print data as formatted JSON to stdout."""
-    click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False))

--- a/unsplash/agent-harness/.manifest.json
+++ b/unsplash/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/unsplash/agent-harness/.manifest.json
+++ b/unsplash/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/unsplash/agent-harness/.manifest.json
+++ b/unsplash/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/unsplash/agent-harness/cli_web/unsplash/commands/photos.py
+++ b/unsplash/agent-harness/cli_web/unsplash/commands/photos.py
@@ -8,6 +8,7 @@ import click
 from curl_cffi import requests as curl_requests
 
 from ..core.client import UnsplashClient
+from ..core.exceptions import UnsplashError
 from ..core.models import format_photo_detail, format_photo_summary
 from ..utils.helpers import handle_errors, print_json
 from ..utils.output import photo_detail_display, photo_table
@@ -58,6 +59,20 @@ def search(query, orientation, color, order_by, page, per_page, use_json):
             photo_table(results, title=f"Search: {query}")
 
 
+@photos.command("autocomplete")
+@click.argument("query")
+@click.option("--json", "use_json", is_flag=True, help="Output as JSON.")
+def autocomplete(query, use_json):
+    """Return Unsplash autocomplete suggestions."""
+    with handle_errors(json_mode=use_json):
+        data = UnsplashClient().autocomplete(query)
+        if use_json:
+            print_json(data)
+        else:
+            for suggestion in data.get("autocomplete", []):
+                click.echo(suggestion.get("query") or suggestion)
+
+
 @photos.command("get")
 @click.argument("photo_id")
 @click.option("--json", "use_json", is_flag=True, help="Output as JSON.")
@@ -71,6 +86,20 @@ def get(photo_id, use_json):
             print_json(detail)
         else:
             photo_detail_display(detail)
+
+
+@photos.command("related")
+@click.argument("photo_id")
+@click.option("--json", "use_json", is_flag=True, help="Output as JSON.")
+def related(photo_id, use_json):
+    """List photos related to a photo ID."""
+    with handle_errors(json_mode=use_json):
+        data = UnsplashClient().get_photo_related(photo_id)
+        results = [format_photo_summary(p) for p in data.get("results", [])]
+        if use_json:
+            print_json({"results": results})
+        else:
+            photo_table(results, title=f"Related to {photo_id}")
 
 
 @photos.command("random")
@@ -114,7 +143,7 @@ def download(photo_id, size, output, use_json):
         urls = photo.get("urls", {})
         url = urls.get(size)
         if not url:
-            raise click.ClickException(f"No '{size}' URL available for photo {photo_id}")
+            raise UnsplashError(f"No '{size}' URL available for photo {photo_id}")
 
         if not output:
             output = f"{photo.get('id', photo_id)}_{size}.jpg"
@@ -122,7 +151,7 @@ def download(photo_id, size, output, use_json):
         out_path = Path(output)
         resp = curl_requests.get(url, impersonate="chrome131", timeout=60)
         if resp.status_code >= 400:
-            raise click.ClickException(f"Download failed: HTTP {resp.status_code}")
+            raise UnsplashError(f"Download failed: HTTP {resp.status_code}")
         out_path.write_bytes(resp.content)
 
         file_size = out_path.stat().st_size

--- a/unsplash/agent-harness/cli_web/unsplash/tests/test_core.py
+++ b/unsplash/agent-harness/cli_web/unsplash/tests/test_core.py
@@ -342,8 +342,8 @@ class TestCLIClick:
 
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["total"] == 1
-        assert data["results"][0]["id"] == "x1"
+        assert data["data"]["total"] == 1
+        assert data["data"]["results"][0]["id"] == "x1"
 
     def test_photos_get_json(self, runner):
         from cli_web.unsplash.unsplash_cli import cli
@@ -373,7 +373,7 @@ class TestCLIClick:
 
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["id"] == "abc"
+        assert data["data"]["id"] == "abc"
 
     def test_topics_list_json(self, runner):
         from cli_web.unsplash.unsplash_cli import cli
@@ -393,8 +393,8 @@ class TestCLIClick:
 
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert len(data) == 1
-        assert data[0]["slug"] == "nature"
+        assert len(data["data"]) == 1
+        assert data["data"][0]["slug"] == "nature"
 
     def test_json_error_on_not_found(self, runner):
         from cli_web.unsplash.unsplash_cli import cli

--- a/unsplash/agent-harness/cli_web/unsplash/unsplash_cli.py
+++ b/unsplash/agent-harness/cli_web/unsplash/unsplash_cli.py
@@ -23,12 +23,13 @@ from .commands.collections import collections
 from .commands.photos import photos
 from .commands.topics import topics
 from .commands.users import users
+from .utils.json_group import JsonGroup
 from .utils.repl_skin import ReplSkin
 
 _skin = ReplSkin("unsplash", version="0.1.0")
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
 @click.option("--version", is_flag=True, help="Show version.")
 @click.pass_context

--- a/unsplash/agent-harness/cli_web/unsplash/utils/doctor.py
+++ b/unsplash/agent-harness/cli_web/unsplash/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/unsplash/agent-harness/cli_web/unsplash/utils/doctor.py
+++ b/unsplash/agent-harness/cli_web/unsplash/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/unsplash/agent-harness/cli_web/unsplash/utils/helpers.py
+++ b/unsplash/agent-harness/cli_web/unsplash/utils/helpers.py
@@ -63,7 +63,12 @@ def handle_errors(json_mode: bool = False):
 
 def print_json(data) -> None:
     """Print data as formatted JSON."""
-    click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
 
 
 def truncate(text: str | None, length: int = 50) -> str:

--- a/unsplash/agent-harness/cli_web/unsplash/utils/json_group.py
+++ b/unsplash/agent-harness/cli_web/unsplash/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/unsplash/agent-harness/cli_web/unsplash/utils/json_group.py
+++ b/unsplash/agent-harness/cli_web/unsplash/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/unsplash/agent-harness/setup.py
+++ b/unsplash/agent-harness/setup.py
@@ -16,7 +16,9 @@ setup(
         # unsplash.com/napi is behind an Anubis JS proof-of-work challenge that
         # blocks plain HTTP clients; camoufox (stealth headless Firefox) solves
         # it. After install, run once: python -m camoufox fetch
-        "camoufox>=0.4",
+        # Keep the Python library and downloaded browser payload reproducible.
+        # The scheduled canary caches the payload using this file's hash.
+        "camoufox==0.5.4",
         # The image CDN (images.unsplash.com) is not challenged — plain
         # curl_cffi is used to download photo bytes.
         "curl_cffi",

--- a/worldcup/agent-harness/.manifest.json
+++ b/worldcup/agent-harness/.manifest.json
@@ -15,22 +15,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/worldcup/agent-harness/.manifest.json
+++ b/worldcup/agent-harness/.manifest.json
@@ -11,6 +11,27 @@
     "http_client": "httpx",
     "auth_type": "none"
   },
-  "shared_files": {},
+  "shared_files": {
+    "utils/repl_skin.py": {
+      "source": "cli-web-core/cli_web_core/repl_skin.py",
+      "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/mcp_server.py": {
+      "source": "cli-web-core/cli_web_core/mcp_server.py",
+      "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/doctor.py": {
+      "source": "cli-web-core/cli_web_core/doctor.py",
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
+    }
+  },
   "overrides": []
 }

--- a/worldcup/agent-harness/.manifest.json
+++ b/worldcup/agent-harness/.manifest.json
@@ -15,22 +15,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/worldcup/agent-harness/WORLDCUP.md
+++ b/worldcup/agent-harness/WORLDCUP.md
@@ -21,8 +21,8 @@ Group standings: `https://site.api.espn.com/apis/v2/sports/soccer/fifa.world/sta
 (by name: `gamesPlayed`, `wins`, `ties`, `losses`, `pointsFor`,
 `pointsAgainst`, `pointDifferential`, `points`, `rank`).
 
-All ESPN endpoints are plain JSON, no auth, no anti-bot — a normal
-User-Agent is sufficient.
+All ESPN endpoints are plain JSON and require no auth. ESPN's Akamai edge does
+inspect the TLS fingerprint, so the client uses a browser-compatible transport.
 
 ## The Odds API (free API key)
 

--- a/worldcup/agent-harness/cli_web/worldcup/commands/fixtures.py
+++ b/worldcup/agent-harness/cli_web/worldcup/commands/fixtures.py
@@ -61,11 +61,11 @@ def get_fixture(ctx, event_id, json_mode):
     json_mode = json_mode or (ctx.obj or {}).get("json", False)
     with handle_errors(json_mode):
         with WorldcupClient() as client:
-            raw = client.scoreboard(dates=_TOURNAMENT_RANGE)
-        events = [ev for ev in raw.get("events", []) if str(ev.get("id")) == str(event_id)]
-        if not events:
+            raw = client.event_summary(event_id)
+        event = raw.get("header") or {}
+        if not event.get("id"):
             raise NotFoundError(f"No match with id {event_id}")
-        match = Match.from_event(events[0]).to_dict()
+        match = Match.from_event(event).to_dict()
 
         if json_mode:
             print_json({"success": True, "data": match})

--- a/worldcup/agent-harness/cli_web/worldcup/commands/teams.py
+++ b/worldcup/agent-harness/cli_web/worldcup/commands/teams.py
@@ -53,7 +53,9 @@ def get_team(ctx, team, json_mode):
     json_mode = json_mode or (ctx.obj or {}).get("json", False)
     with handle_errors(json_mode):
         with WorldcupClient() as client:
-            row = resolve_team(team, _all_teams(client))
+            resolved = resolve_team(team, _all_teams(client))
+            raw = client.team(resolved["id"])
+            row = Team.from_team(raw.get("team") or {}).to_dict()
 
         if json_mode:
             print_json({"success": True, "data": row})

--- a/worldcup/agent-harness/cli_web/worldcup/core/client.py
+++ b/worldcup/agent-harness/cli_web/worldcup/core/client.py
@@ -1,6 +1,6 @@
 """HTTP client for cli-web-worldcup.
 
-Two read-only upstreams, both plain JSON over httpx:
+Two read-only upstreams, both plain JSON over HTTPS:
 
 - **ESPN** (``site.api.espn.com``) — public, no auth. ``fifa.world`` is the
   men's FIFA World Cup. Fixtures, teams, rosters, and group standings.
@@ -11,7 +11,7 @@ Two read-only upstreams, both plain JSON over httpx:
 
 from __future__ import annotations
 
-import httpx
+from curl_cffi import requests
 
 from .exceptions import AuthError, NetworkError, raise_for_status
 
@@ -29,19 +29,21 @@ class WorldcupClient:
 
     def __init__(self, odds_api_key: str | None = None):
         self._odds_api_key = odds_api_key
-        self._client = httpx.Client(
-            timeout=httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=30.0),
+        # ESPN's Akamai edge currently returns 403 to httpx's TLS fingerprint.
+        # A browser fingerprint is required even though the endpoint is public.
+        self._client = requests.Session(
+            impersonate="chrome",
             headers={"User-Agent": "cli-web-worldcup/0.1.0"},
-            follow_redirects=True,
         )
 
     def _get(self, url: str, params: dict | None = None) -> dict:
         try:
-            resp = self._client.get(url, params=params)
-        except httpx.ConnectError as exc:
-            raise NetworkError(f"Connection failed: {exc}") from exc
-        except httpx.TimeoutException as exc:
-            raise NetworkError(f"Request timed out: {exc}") from exc
+            resp = self._client.get(url, params=params, timeout=30, allow_redirects=True)
+        except requests.errors.RequestsError as exc:
+            raise NetworkError(f"Request failed: {exc}") from exc
+        # A 403 from a public ESPN feed is edge blocking, not expired auth.
+        if resp.status_code == 403 and url.startswith("https://site.api.espn.com/"):
+            raise NetworkError("ESPN rejected the request at its edge (HTTP 403)")
         raise_for_status(resp)
         try:
             return resp.json()

--- a/worldcup/agent-harness/cli_web/worldcup/core/models.py
+++ b/worldcup/agent-harness/cli_web/worldcup/core/models.py
@@ -33,14 +33,16 @@ class Match:
         comps = ev.get("competitions") or [{}]
         comp = comps[0]
         home = away = ""
+        home_abbr = away_abbr = ""
         home_score = away_score = None
         for c in comp.get("competitors", []):
             name = (c.get("team") or {}).get("displayName", "")
+            abbr = (c.get("team") or {}).get("abbreviation", "")
             score = c.get("score")
             if c.get("homeAway") == "home":
-                home, home_score = name, score
+                home, home_abbr, home_score = name, abbr, score
             else:
-                away, away_score = name, score
+                away, away_abbr, away_score = name, abbr, score
         notes = comp.get("notes") or []
         stage = notes[0].get("headline", "") if notes else ""
         # The competition-level venue carries `fullName`; the event-level one
@@ -53,11 +55,16 @@ class Match:
         )
         return cls(
             id=str(ev.get("id", "")),
-            date=ev.get("date", ""),
-            name=ev.get("name", ""),
-            short_name=ev.get("shortName", ""),
-            status=((ev.get("status") or {}).get("type") or {}).get("description", ""),
-            stage=stage,
+            date=ev.get("date") or comp.get("date", ""),
+            name=ev.get("name") or (f"{away} at {home}" if home or away else ""),
+            short_name=ev.get("shortName")
+            or (f"{away_abbr} @ {home_abbr}" if home_abbr or away_abbr else ""),
+            status=(
+                ((ev.get("status") or comp.get("status") or {}).get("type") or {}).get(
+                    "description", ""
+                )
+            ),
+            stage=stage or (ev.get("season") or {}).get("name", ""),
             venue=venue,
             home=home,
             away=away,

--- a/worldcup/agent-harness/cli_web/worldcup/tests/test_core.py
+++ b/worldcup/agent-harness/cli_web/worldcup/tests/test_core.py
@@ -14,6 +14,7 @@ import pytest
 from cli_web.worldcup.core.client import WorldcupClient
 from cli_web.worldcup.core.exceptions import (
     AuthError,
+    NetworkError,
     NotFoundError,
     RateLimitError,
     ServerError,
@@ -167,7 +168,7 @@ def test_odds_without_key_raises_auth_error():
         client.odds()
 
 
-# ── HTTP status mapping (mock httpx) ─────────────────────────────────────────
+# ── HTTP status mapping (mock transport) ─────────────────────────────────────
 
 
 class _Resp:
@@ -185,7 +186,7 @@ class _Resp:
     "status,exc",
     [
         (401, AuthError),
-        (403, AuthError),
+        (403, NetworkError),
         (404, NotFoundError),
         (429, RateLimitError),
         (500, ServerError),

--- a/worldcup/agent-harness/cli_web/worldcup/tests/test_e2e.py
+++ b/worldcup/agent-harness/cli_web/worldcup/tests/test_e2e.py
@@ -173,6 +173,8 @@ class TestCLISubprocess:
             [*cli_cmd, "--json", "odds", "list"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=60,
             env=env,
         )

--- a/worldcup/agent-harness/cli_web/worldcup/utils/doctor.py
+++ b/worldcup/agent-harness/cli_web/worldcup/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/worldcup/agent-harness/cli_web/worldcup/utils/doctor.py
+++ b/worldcup/agent-harness/cli_web/worldcup/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/worldcup/agent-harness/cli_web/worldcup/utils/helpers.py
+++ b/worldcup/agent-harness/cli_web/worldcup/utils/helpers.py
@@ -114,4 +114,9 @@ def handle_errors(json_mode: bool = False):
 
 def print_json(data) -> None:
     """Print data as formatted JSON to stdout."""
-    print(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))

--- a/worldcup/agent-harness/cli_web/worldcup/utils/json_group.py
+++ b/worldcup/agent-harness/cli_web/worldcup/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/worldcup/agent-harness/cli_web/worldcup/utils/json_group.py
+++ b/worldcup/agent-harness/cli_web/worldcup/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/worldcup/agent-harness/cli_web/worldcup/worldcup_cli.py
+++ b/worldcup/agent-harness/cli_web/worldcup/worldcup_cli.py
@@ -16,6 +16,7 @@ import shlex
 
 import click
 
+from .utils.json_group import JsonGroup
 from .utils.repl_skin import ReplSkin
 
 _skin = ReplSkin(app="worldcup", version="0.1.0", display_name="World Cup 2026")
@@ -24,7 +25,7 @@ _skin = ReplSkin(app="worldcup", version="0.1.0", display_name="World Cup 2026")
 # ── Main CLI group ─────────────────────────────────────────────────────────────
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
 @click.version_option("0.1.0", prog_name="cli-web-worldcup")
 @click.pass_context

--- a/worldcup/agent-harness/setup.py
+++ b/worldcup/agent-harness/setup.py
@@ -9,7 +9,9 @@ setup(
     python_requires=">=3.10",
     install_requires=[
         "click>=8.0",
-        "httpx",
+        # ESPN rejects httpx's TLS fingerprint with an Akamai 403 even though
+        # the feed is public. curl_cffi supplies a normal browser fingerprint.
+        "curl_cffi>=0.11",
         "rich>=13.0",
         "prompt_toolkit>=3.0",
     ],

--- a/youtube/agent-harness/.manifest.json
+++ b/youtube/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
       "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "synced_at": "2026-08-16T09:15:39Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
-      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
-      "synced_at": "2026-08-16T09:07:56Z"
+      "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
+      "synced_at": "2026-08-16T09:15:39Z"
     }
   },
   "overrides": []

--- a/youtube/agent-harness/.manifest.json
+++ b/youtube/agent-harness/.manifest.json
@@ -13,22 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "sha256": "97632944193b2710693c0c0428590552c77d665a7e79e592d5b45c4003dd55aa",
+      "synced_at": "2026-08-16T09:21:17Z"
     },
     "utils/json_group.py": {
       "source": "cli-web-core/cli_web_core/json_group.py",
       "sha256": "c26e32af048e3abf7b8d1fd7b49d5ad43c91f19f13450d7f528730b584c7caaf",
-      "synced_at": "2026-08-16T09:15:39Z"
+      "synced_at": "2026-08-16T09:21:17Z"
     }
   },
   "overrides": []

--- a/youtube/agent-harness/.manifest.json
+++ b/youtube/agent-harness/.manifest.json
@@ -13,17 +13,22 @@
     "utils/repl_skin.py": {
       "source": "cli-web-core/cli_web_core/repl_skin.py",
       "sha256": "7c8a8c6d0e52058486ccf3a84c34fa544ebbb054b0d297d2ed53c621d7819895",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/mcp_server.py": {
       "source": "cli-web-core/cli_web_core/mcp_server.py",
       "sha256": "e6b0d3479e3cef2134f2000880a0bc06ab3747047626249051f0804d857bafdc",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "synced_at": "2026-08-16T09:07:56Z"
     },
     "utils/doctor.py": {
       "source": "cli-web-core/cli_web_core/doctor.py",
-      "sha256": "1c8deef391d6aee0a31b654af1cc1e97f4d25f7cde8cf4d6a8089b88f1c24c04",
-      "synced_at": "2026-06-10T12:05:01Z"
+      "sha256": "a6c77af50b593f75f95276cd259911ce8af3481d6f575d9420b9c005fb082846",
+      "synced_at": "2026-08-16T09:07:56Z"
+    },
+    "utils/json_group.py": {
+      "source": "cli-web-core/cli_web_core/json_group.py",
+      "sha256": "a6971c4b6981b9c8a90b27da5aef5a7efd4513422db6e91935a93df6c07d32f2",
+      "synced_at": "2026-08-16T09:07:56Z"
     }
   },
   "overrides": []

--- a/youtube/agent-harness/cli_web/youtube/tests/test_core.py
+++ b/youtube/agent-harness/cli_web/youtube/tests/test_core.py
@@ -379,8 +379,8 @@ class TestCLIClick:
         result = runner.invoke(cli, ["search", "videos", "test", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["query"] == "test"
-        assert len(data["videos"]) == 1
+        assert data["data"]["query"] == "test"
+        assert len(data["data"]["videos"]) == 1
 
     @patch("cli_web.youtube.commands.video.YouTubeClient")
     def test_video_get_json(self, mock_class):
@@ -396,7 +396,7 @@ class TestCLIClick:
         result = runner.invoke(cli, ["video", "get", "abc123", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["id"] == "abc123"
+        assert data["data"]["id"] == "abc123"
 
     @patch("cli_web.youtube.commands.video.YouTubeClient")
     def test_video_get_extracts_id_from_url(self, mock_class):
@@ -573,7 +573,7 @@ class TestTranscript:
         mock_class.return_value = mock_client
         result = CliRunner().invoke(cli, ["transcript", "get", "abc123", "--json"])
         assert result.exit_code == 0
-        assert json.loads(result.output)["text"] == "hi"
+        assert json.loads(result.output)["data"]["text"] == "hi"
 
     @patch("cli_web.youtube.commands.transcript.YouTubeClient")
     def test_transcript_get_text_only(self, mock_class):

--- a/youtube/agent-harness/cli_web/youtube/utils/doctor.py
+++ b/youtube/agent-harness/cli_web/youtube/utils/doctor.py
@@ -165,7 +165,9 @@ def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
         try:
             from camoufox.pkgman import camoufox_path
 
-            executable = Path(camoufox_path())
+            # Doctor is diagnostic and must never download a browser or write
+            # to the cache as a side effect of checking the local setup.
+            executable = Path(camoufox_path(download_if_missing=False))
             if executable.exists():
                 return [DoctorCheck("camoufox browser", "ok", str(executable))]
             return [

--- a/youtube/agent-harness/cli_web/youtube/utils/doctor.py
+++ b/youtube/agent-harness/cli_web/youtube/utils/doctor.py
@@ -137,12 +137,57 @@ def _check_optional_deps() -> list[DoctorCheck]:
     return checks
 
 
+def _check_browser_runtime(app_name: str) -> list[DoctorCheck]:
+    """Verify browser payloads required by public browser-backed CLIs."""
+    if app_name == "gai":
+        if importlib.util.find_spec("playwright") is None:
+            return [DoctorCheck("chromium browser", "fail", "playwright is not installed")]
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                executable = Path(playwright.chromium.executable_path)
+            if executable.is_file():
+                return [DoctorCheck("chromium browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "chromium browser",
+                    "fail",
+                    "payload missing — run: python -m playwright install chromium",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("chromium browser", "fail", str(exc))]
+
+    if app_name in {"unsplash", "futbin"}:
+        if importlib.util.find_spec("camoufox") is None:
+            return [DoctorCheck("camoufox browser", "fail", "camoufox is not installed")]
+        try:
+            from camoufox.pkgman import camoufox_path
+
+            executable = Path(camoufox_path())
+            if executable.exists():
+                return [DoctorCheck("camoufox browser", "ok", str(executable))]
+            return [
+                DoctorCheck(
+                    "camoufox browser",
+                    "fail",
+                    "payload missing — run: python -m camoufox fetch",
+                )
+            ]
+        except Exception as exc:
+            return [DoctorCheck("camoufox browser", "fail", str(exc))]
+
+    return []
+
+
 def run_doctor(app_name: str, pkg: str) -> list[DoctorCheck]:
     checks = [
         _check_python(),
         _check_entry_point(app_name),
         _check_config_dir(app_name),
         *_check_auth(app_name, pkg),
+        *_check_browser_runtime(app_name),
         *_check_optional_deps(),
     ]
     return checks

--- a/youtube/agent-harness/cli_web/youtube/utils/helpers.py
+++ b/youtube/agent-harness/cli_web/youtube/utils/helpers.py
@@ -64,7 +64,12 @@ def resolve_json_mode(use_json: bool) -> bool:
 
 def print_json(data) -> None:
     """Print data as formatted JSON."""
-    click.echo(json.dumps(data, indent=2, default=str))
+    payload = (
+        data
+        if isinstance(data, dict) and ("success" in data or data.get("error"))
+        else {"success": True, "data": data}
+    )
+    click.echo(json.dumps(payload, indent=2, default=str))
 
 
 def print_error_json(exc: YouTubeError) -> None:

--- a/youtube/agent-harness/cli_web/youtube/utils/json_group.py
+++ b/youtube/agent-harness/cli_web/youtube/utils/json_group.py
@@ -1,0 +1,61 @@
+"""Click group that preserves structured errors before command callbacks run."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+
+class JsonGroup(click.Group):  # type: ignore[misc]
+    """Render Click usage errors as JSON when ``--json`` was requested."""
+
+    def main(
+        self,
+        args: list[str] | tuple[str, ...] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        if not standalone_mode:
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+
+        actual_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().main(
+                args=actual_args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.UsageError as exc:
+            if "--json" in actual_args:
+                click.echo(
+                    json.dumps(
+                        {"error": True, "code": "USAGE_ERROR", "message": exc.format_message()}
+                    )
+                )
+            else:
+                exc.show()
+            raise SystemExit(exc.exit_code) from exc
+        except click.exceptions.Exit as exc:
+            raise SystemExit(exc.exit_code) from exc
+        except click.Abort as exc:
+            if "--json" in actual_args:
+                click.echo(json.dumps({"error": True, "code": "ABORTED", "message": "Aborted"}))
+            else:
+                click.echo("Aborted!", err=True)
+            raise SystemExit(1) from exc

--- a/youtube/agent-harness/cli_web/youtube/utils/json_group.py
+++ b/youtube/agent-harness/cli_web/youtube/utils/json_group.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from typing import Any
 
 import click
 
 
-class JsonGroup(click.Group):  # type: ignore[misc]
+class JsonGroup(click.Group):
     """Render Click usage errors as JSON when ``--json`` was requested."""
 
     def main(
         self,
-        args: list[str] | tuple[str, ...] | None = None,
+        args: Sequence[str] | None = None,
         prog_name: str | None = None,
         complete_var: str | None = None,
         standalone_mode: bool = True,

--- a/youtube/agent-harness/cli_web/youtube/youtube_cli.py
+++ b/youtube/agent-harness/cli_web/youtube/youtube_cli.py
@@ -24,10 +24,12 @@ from cli_web.youtube.commands.video import video_group
 from cli_web.youtube.core.exceptions import YouTubeError
 from cli_web.youtube.utils.repl_skin import ReplSkin
 
+from .utils.json_group import JsonGroup
+
 _skin = ReplSkin(app="youtube", version=__version__)
 
 
-@click.group(invoke_without_command=True)
+@click.group(cls=JsonGroup, invoke_without_command=True)
 @click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
 @click.version_option(__version__, prog_name="cli-web-youtube")
 @click.pass_context


### PR DESCRIPTION
## Summary

- exercise the full 20-CLI read-only surface against live services and repair reproducible routing, parsing, transport, auth-refresh, and output-contract failures
- add structured JSON usage errors and normalized success envelopes across the fleet
- make browser-backed CLIs verify and cache their Camoufox/Chromium payloads instead of reporting false-green diagnostics
- strengthen CI with strict fleet validation, offline subprocess E2E coverage, a 50% coverage floor, immutable Action pins, Dependabot, and CodeQL
- refresh registry/docs/plugin metadata and expose previously captured read endpoints

## Notable runtime fixes

- FUTBIN and World Cup browser-compatible transports
- bounded three-attempt NotebookLM and Stitch auth refresh; corrected Reddit/LinkedIn/auth error behavior
- LinkedIn company routing and Pexels search-to-detail round trips
- richer Product Hunt extraction, GAI empty-response/CAPTCHA handling, and new Hacker News/Pexels/Stitch/Unsplash/World Cup read commands
- canonical exit codes for auth, not-found, rate-limit, server, and network failures on the repaired surfaces

## Verification

- live read-only sweep across all 20 CLIs (138 commands initially, followed by focused post-fix reruns)
- public reads pass for healthy services; credentials-required commands return structured `AUTH_EXPIRED`; GAI CAPTCHA returns `CAPTCHA_REQUIRED`; temporary upstream blocks are no longer false successes
- `722 passed, 19 skipped`; coverage `53.36%` with floor `50%`
- every per-CLI `test_core.py` suite passes
- all 20 strict checklists pass
- 140 fleet contract tests pass
- Ruff, Ruff format, mypy, registry/docs/drift checks pass
- workflow YAML parses; `pip-audit` reports no known vulnerabilities
- GitHub Actions are immutable-SHA pinned; secret-pattern scan is clean

Fixes #49
