### PR TITLE
fix(docs): sync public installs and registry site

### DIFF
--- a/.claude/skills/booking-cli/SKILL.md
+++ b/.claude/skills/booking-cli/SKILL.md
@@ -6,7 +6,7 @@ description: Searches Booking.com from the terminal via cli-web-booking — find
 # cli-web-booking
 
 Read-only Booking.com search: property search, property detail, destination autocomplete. AWS WAF protection is handled via stored cookies (`auth login`); autocomplete works without them.
-Install: `pip install cli-web-booking`
+Install: `pip install "cli-web-booking[auth]"`, then `playwright install chromium`.
 
 ## Commands
 

--- a/.claude/skills/chatgpt-cli/SKILL.md
+++ b/.claude/skills/chatgpt-cli/SKILL.md
@@ -6,7 +6,7 @@ description: Drives ChatGPT from the terminal via cli-web-chatgpt — ask questi
 # cli-web-chatgpt
 
 ChatGPT on the command line: chat, image generation, conversation browsing. Chat/image commands run a headless stealth browser (Camoufox) to pass Cloudflare; read-only commands are instant HTTP.
-Install: `pip install cli-web-chatgpt`
+Install: `pip install "cli-web-chatgpt[auth]"`, then `python -m camoufox fetch` and `playwright install chromium`.
 
 ## Commands
 

--- a/.claude/skills/gai-cli/SKILL.md
+++ b/.claude/skills/gai-cli/SKILL.md
@@ -6,7 +6,7 @@ description: Queries Google AI Mode via cli-web-gai — submits a question, retu
 # cli-web-gai
 
 Google AI Mode search: AI answers with source references, rendered through headless Playwright (Chromium).
-Install: `pip install cli-web-gai`
+Install: `pip install cli-web-gai`, then `playwright install chromium`.
 
 ## Commands
 

--- a/.claude/skills/linkedin-cli/SKILL.md
+++ b/.claude/skills/linkedin-cli/SKILL.md
@@ -6,7 +6,7 @@ description: Interacts with LinkedIn via the cli-web-linkedin command-line tool 
 # cli-web-linkedin
 
 Full LinkedIn client: search, profiles, feed, posting, reactions, comments, network, and messaging. All commands require `auth login` first.
-Install: `pip install cli-web-linkedin`
+Install: `pip install "cli-web-linkedin[browser]"`, then `playwright install chromium`.
 
 ## Commands
 

--- a/.claude/skills/notebooklm-cli/SKILL.md
+++ b/.claude/skills/notebooklm-cli/SKILL.md
@@ -6,7 +6,7 @@ description: Drives Google NotebookLM via the cli-web-notebooklm command-line to
 # cli-web-notebooklm
 
 Manage NotebookLM notebooks, sources, chat, and artifact generation. Requires Google auth (`auth login`).
-Install: `pip install cli-web-notebooklm`
+Install: `pip install "cli-web-notebooklm[auth]"`, then `playwright install chromium`.
 
 ## Commands
 

--- a/.claude/skills/reddit-cli/SKILL.md
+++ b/.claude/skills/reddit-cli/SKILL.md
@@ -6,7 +6,7 @@ description: Browses and interacts with Reddit via the cli-web-reddit command-li
 # cli-web-reddit
 
 Browse Reddit without auth; vote, comment, submit, and manage subscriptions after `auth login`.
-Install: `pip install cli-web-reddit`
+Install: `pip install cli-web-reddit`, then `playwright install chromium`.
 
 ## Commands
 

--- a/.claude/skills/stitch-cli/SKILL.md
+++ b/.claude/skills/stitch-cli/SKILL.md
@@ -6,7 +6,7 @@ description: Drives Google Stitch (stitch.withgoogle.com), the AI UI design tool
 # cli-web-stitch
 
 Generate and manage Google Stitch AI UI designs. Requires Google SSO auth (`auth login`).
-Install: `pip install cli-web-stitch`
+Install: `pip install "cli-web-stitch[auth]"`, then `playwright install chromium`.
 
 ## Commands
 

--- a/.claude/skills/unsplash-cli/SKILL.md
+++ b/.claude/skills/unsplash-cli/SKILL.md
@@ -6,7 +6,7 @@ description: Searches and downloads free Unsplash photos via the cli-web-unsplas
 # cli-web-unsplash
 
 Search, explore, and download Unsplash photos (read-only, no auth).
-Install: `pip install cli-web-unsplash`
+Install: `pip install cli-web-unsplash`, then run `python -m camoufox fetch` once.
 
 ## Commands
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -11,15 +11,16 @@ Get from zero to a working CLI in under 5 minutes.
 ## Install the Plugin
 
 ```bash
-git clone https://github.com/ItamarZand88/CLI-Anything-WEB.git
-cd CLI-Anything-Web
-claude plugin install ./cli-anything-web-plugin
+# Inside Claude Code
+/plugin marketplace add ItamarZand88/CLI-Anything-WEB
+/plugin install cli-anything-web
+/reload-plugins
 ```
 
 ## Generate a CLI for Any Website
 
 ```bash
-claude "/cli-anything-web https://example.com"
+/cli-anything-web https://example.com
 ```
 
 The plugin walks through 4 phases automatically: capture traffic, analyze APIs, generate code, and publish.
@@ -29,7 +30,7 @@ The plugin walks through 4 phases automatically: capture traffic, analyze APIs, 
 The easiest way to see what gets generated — install and run `cli-web-gh-trending`:
 
 ```bash
-pip install -e gh-trending/agent-harness
+pip install cli-web-gh-trending
 cli-web-gh-trending repos list
 cli-web-gh-trending repos list --language python --since weekly --json
 ```
@@ -42,6 +43,6 @@ cli-web-gh-trending
 
 ## Next Steps
 
-- See the full [README](README.md) for architecture details and all 19 generated CLIs
+- See the full [README](README.md) for architecture details and all 20 generated CLIs
 - Browse `registry.json` for a machine-readable index of every CLI
 - Read `CLAUDE.md` for contributor conventions

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The agent opens a browser, asks you to log in if needed, captures traffic, and g
 | [`cli-web-airbnb`](airbnb/) | Airbnb | SSR HTML + niobeClientData (curl_cffi) | None | [📖 Skill](.claude/skills/airbnb-cli/SKILL.md) | Search stays, listing details, amenities, host info, autocomplete locations |
 | [`cli-web-amazon`](amazon/) | amazon.com | SSR HTML + REST JSON (curl_cffi) | None | [📖 Skill](.claude/skills/amazon-cli/SKILL.md) | Search products, view details, browse bestsellers |
 | [`cli-web-tripadvisor`](tripadvisor/) | TripAdvisor | SSR HTML + JSON-LD (curl_cffi) | None | [📖 Skill](.claude/skills/tripadvisor-cli/SKILL.md) | Search locations, hotels, restaurants, and attractions |
-| [`cli-web-linkedin`](linkedin/) | LinkedIn | GraphQL + Voyager REST (curl_cffi) | Cookie | [📖 Skill](.claude/skills/linkedin-cli/SKILL.md) | Search, feed, profiles, jobs, posts, reactions, comments, network, messaging (26 cmds) |
+| [`cli-web-linkedin`](linkedin/) | LinkedIn | GraphQL + Voyager REST (curl_cffi) | Cookie | [📖 Skill](.claude/skills/linkedin-cli/SKILL.md) | Search, feed, profiles, jobs, posts, reactions, comments, network, and messaging |
 | [`cli-web-capitoltrades`](capitoltrades/) | Capitol Trades | SSR HTML + BFF JSON (curl_cffi) | None | [📖 Skill](.claude/skills/capitoltrades-cli/SKILL.md) | US congressional stock trades (STOCK Act) — trades, politicians, issuers, price history |
 | [`cli-web-worldcup`](worldcup/) | ESPN / FIFA World Cup 2026 | REST JSON (ESPN + The Odds API) | None | [📖 Skill](.claude/skills/worldcup-cli/SKILL.md) | FIFA World Cup 2026 — fixtures, nations, squads, group standings, and bookmaker odds (read-only) |
 <!-- fleet-table:end -->
@@ -152,7 +152,7 @@ cli-web-futbin players search --name "Messi" --json
 
 **NotebookLM** — requires Google login
 ```bash
-pip install cli-web-notebooklm
+pip install "cli-web-notebooklm[auth]"
 cli-web-notebooklm auth login
 cli-web-notebooklm notebooks list --json
 ```
@@ -171,14 +171,14 @@ cli-web-unsplash photos search "mountains" --json
 
 **Booking.com** — hotel search
 ```bash
-pip install cli-web-booking
+pip install "cli-web-booking[auth]"
 cli-web-booking auth login        # required — fetches WAF browser cookies
 cli-web-booking search find "Paris" --json
 ```
 
 **Google Stitch** — requires Google SSO login
 ```bash
-pip install cli-web-stitch
+pip install "cli-web-stitch[auth]"
 cli-web-stitch auth login
 cli-web-stitch projects list --json
 ```
@@ -227,7 +227,7 @@ cli-web-tripadvisor attractions search "London" --json
 
 **ChatGPT** — ask questions, generate images
 ```bash
-pip install cli-web-chatgpt
+pip install "cli-web-chatgpt[auth]"
 cli-web-chatgpt auth login        # optional — required for image generation & conversations
 cli-web-chatgpt chat ask "Explain quantum computing in one sentence" --json
 cli-web-chatgpt chat image "A sunset over mountains" --output sunset.png --json
@@ -256,7 +256,7 @@ cli-web-amazon bestsellers electronics --json
 
 **LinkedIn** — search people/jobs/companies, feed, profiles, post, network, messaging (auth required)
 ```bash
-pip install cli-web-linkedin
+pip install "cli-web-linkedin[browser]"
 cli-web-linkedin auth login        # required — browser-based LinkedIn SSO
 
 # Search people and jobs

--- a/booking/agent-harness/cli_web/booking/README.md
+++ b/booking/agent-harness/cli_web/booking/README.md
@@ -5,8 +5,8 @@ Agent-native CLI for [Booking.com](https://www.booking.com) — search hotels, g
 ## Install
 
 ```bash
-cd booking/agent-harness
-pip install -e .
+pip install "cli-web-booking[auth]"
+playwright install chromium
 ```
 
 ## Auth Setup

--- a/capitoltrades/agent-harness/cli_web/capitoltrades/README.md
+++ b/capitoltrades/agent-harness/cli_web/capitoltrades/README.md
@@ -6,8 +6,7 @@ US congressional stock trades, politicians, issuers, and articles from the termi
 ## Install
 
 ```bash
-cd agent-harness
-pip install -e .
+pip install cli-web-capitoltrades
 ```
 
 Binary: `cli-web-capitoltrades`

--- a/chatgpt/agent-harness/cli_web/chatgpt/README.md
+++ b/chatgpt/agent-harness/cli_web/chatgpt/README.md
@@ -5,8 +5,8 @@ CLI for ChatGPT web interface — ask questions, generate images, download image
 ## Installation
 
 ```bash
-cd chatgpt/agent-harness
-pip install -e ".[auth]"
+pip install "cli-web-chatgpt[auth]"
+python -m camoufox fetch
 playwright install chromium
 ```
 

--- a/cli-anything-web-plugin/QUICKSTART.md
+++ b/cli-anything-web-plugin/QUICKSTART.md
@@ -10,6 +10,14 @@ npx @playwright/cli@latest --version
 ```
 If this fails, install Node.js from https://nodejs.org/
 
+Install the plugin inside Claude Code:
+
+```bash
+/plugin marketplace add ItamarZand88/CLI-Anything-WEB
+/plugin install cli-anything-web
+/reload-plugins
+```
+
 ## Step 2: Generate a CLI (5-10 minutes)
 
 ```bash

--- a/cli-anything-web-plugin/README.md
+++ b/cli-anything-web-plugin/README.md
@@ -12,10 +12,13 @@
 
 ## Quick Start
 
-### Step 1: Load the plugin
+### Step 1: Install the plugin
 
 ```bash
-claude --plugin-dir /path/to/cli-anything-web-plugin
+# Inside Claude Code
+/plugin marketplace add ItamarZand88/CLI-Anything-WEB
+/plugin install cli-anything-web
+/reload-plugins
 ```
 
 ### Step 2: Generate a CLI

--- a/cli-anything-web-plugin/skills/standards/SKILL.md
+++ b/cli-anything-web-plugin/skills/standards/SKILL.md
@@ -262,7 +262,7 @@ entry, then run the generators — never edit those outputs by hand:
 ```bash
 # 1. Add the entry to registry.json (schema below), then:
 cli-web-devkit registry validate     # entry <-> fleet cross-check
-cli-web-devkit docs                  # regenerates README table + install block
+cli-web-devkit docs                  # regenerates README regions + registry site data
 cli-web-devkit about --apply         # syncs the GitHub "About" CLI count (needs gh admin)
 cli-web-devkit resync --app <app>    # vendored files in sync + manifest updated
 cli-web-devkit drift                 # must report 0 drifted/missing
@@ -274,7 +274,6 @@ python -m pytest tests/contract -q -k <app>
 Remaining hand-edited files (independent — update in parallel if you like):
 - `CHANGELOG.md` — entry under [Unreleased] -> Added
 - `CLAUDE.md` — row in the Generated CLIs table
-- `docs/registry/index.html` — entry in the JS data array
 - `README.md` hero badge counts (outside the generated markers)
 - `cli_web/<app>/README.md` — fill in the scaffolded skeleton
 
@@ -316,8 +315,9 @@ Create `<git-root>/.claude/skills/<app>-cli/SKILL.md`:
 
 ## Update Repository README
 
-Add the new CLI to the examples table in `README.md` (CLI name, website, protocol,
-auth type, description) and add a quick-start example in the "Try Them" section.
+Add presentation metadata to `registry.json`, then run `cli-web-devkit docs` to
+regenerate the README table and registry site. Add a hand-written quick-start
+example in the README's "Try Them" section only when it adds distinct value.
 
 ### Update registry.json and CLAUDE.md
 
@@ -331,7 +331,11 @@ Add the new CLI to `registry.json` at the repo root:
   "directory": "<app>/agent-harness",
   "namespace": "cli_web.<app>",
   "commands": ["<cmd1>", "<cmd2>", ...],
-  "install": "pip install -e <app>/agent-harness"
+  "install": "pip install cli-web-<app>",
+  "description": "<one-line public description>",
+  "site_icon": "<short label>",
+  "site_category": "<display category>",
+  "site_tags": ["<filter-tag>"]
 }
 ```
 
@@ -365,12 +369,12 @@ The pipeline is NOT done until ALL of these are checked:
 ### Repo-Level Updates
 - [ ] `registry.json` — entry with name, website, protocol, auth, commands,
       install, description, skill path (+ `canary` read-only invocations for
-      no-auth CLIs). The CI matrix and README table derive from this entry.
+      no-auth CLIs). The CI matrix, README table, and registry site derive from
+      this entry.
 - [ ] `cli-web-devkit registry validate` + `docs` + `drift` all green
 - [ ] `python -m pytest tests/contract -k <app>` passes (offline contract)
 - [ ] `CHANGELOG.md` — entry added under [Unreleased] → Added
 - [ ] `CLAUDE.md` — new row in Generated CLIs table
-- [ ] `docs/registry/index.html` — entry added to JS data array
 - [ ] `README.md` hero badge counts updated (outside the generated markers)
 - [ ] Branch protection: if required status checks are pinned by job name, add
       the new matrix job names — the matrix itself updates automatically from

--- a/codewiki/agent-harness/cli_web/codewiki/README.md
+++ b/codewiki/agent-harness/cli_web/codewiki/README.md
@@ -5,8 +5,7 @@ CLI for [Google Code Wiki](https://codewiki.google/) — browse AI-generated doc
 ## Installation
 
 ```bash
-cd codewiki/agent-harness
-pip install -e .
+pip install cli-web-codewiki
 ```
 
 ## Usage

--- a/devkit/cli_web_devkit/cli.py
+++ b/devkit/cli_web_devkit/cli.py
@@ -37,14 +37,14 @@ def _cmd_docs(args: argparse.Namespace) -> int:
     fresh = generate_docs(args.root, check=args.check)
     if args.check:
         if fresh:
-            print("README.md fleet sections are up to date")
+            print("Public README and registry site are up to date")
             return 0
         print(
-            "README.md fleet sections are STALE — run: cli-web-devkit docs",
+            "Public README or registry site is STALE — run: cli-web-devkit docs",
             file=sys.stderr,
         )
         return 1
-    print("README.md regenerated" if not fresh else "README.md already up to date")
+    print("Public docs regenerated" if not fresh else "Public docs already up to date")
     return 0
 
 

--- a/devkit/cli_web_devkit/docs.py
+++ b/devkit/cli_web_devkit/docs.py
@@ -1,14 +1,16 @@
-"""Generate fleet documentation from registry.json.
+"""Generate fleet documentation and the registry site from registry.json.
 
 README.md's CLI table and install command are generated artifacts: the
 content between ``<!-- fleet-table:start -->`` / ``<!-- fleet-table:end -->``
 and ``<!-- fleet-install:start -->`` / ``<!-- fleet-install:end -->`` markers
-is rewritten from the registry, so the docs can never drift from the fleet
-again. ``--check`` mode (used in CI) fails if the README is stale.
+is rewritten from the registry. The GitHub Pages registry's fleet count and
+JavaScript data are generated from the same source. ``--check`` mode (used in
+CI) fails if either public surface is stale.
 """
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -28,6 +30,10 @@ TABLE_START = "<!-- fleet-table:start -->"
 TABLE_END = "<!-- fleet-table:end -->"
 INSTALL_START = "<!-- fleet-install:start -->"
 INSTALL_END = "<!-- fleet-install:end -->"
+SITE_COUNT_START = "<!-- fleet-count:start -->"
+SITE_COUNT_END = "<!-- fleet-count:end -->"
+SITE_DATA_START = "// fleet-data:start"
+SITE_DATA_END = "// fleet-data:end"
 
 
 def render_table(registry: Registry) -> str:
@@ -72,6 +78,33 @@ def render_install(registry: Registry) -> str:
     )
 
 
+def render_site_data(registry: Registry) -> str:
+    """Render the public registry cards from the machine-readable registry."""
+    cards = []
+    for entry in registry.clis:
+        extra = entry.extra
+        cards.append(
+            {
+                "name": entry.app_dir,
+                "icon": extra.get("site_icon", entry.app_dir[:1].upper()),
+                "site": extra.get("display_website", entry.website),
+                "desc": extra.get("description", ""),
+                "category": extra.get("site_category", "Other"),
+                "tags": extra.get("site_tags", ["other"]),
+                "proto": entry.protocol,
+                "auth": _AUTH_DISPLAY.get(entry.auth, entry.auth),
+                "cmds": entry.commands,
+                "install": entry.install,
+                "setup": extra.get("post_install", []),
+                "n": len(entry.commands),
+                "url": (
+                    f"https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/{entry.app_dir}"
+                ),
+            }
+        )
+    return "const data = " + json.dumps(cards, ensure_ascii=False, indent=2) + ";"
+
+
 def _replace_region(text: str, start: str, end: str, content: str) -> str:
     pattern = re.compile(re.escape(start) + r".*?" + re.escape(end), re.S)
     if not pattern.search(text):
@@ -80,15 +113,37 @@ def _replace_region(text: str, start: str, end: str, content: str) -> str:
 
 
 def generate(root: Path, check: bool = False) -> bool:
-    """Regenerate README regions. Returns True if the README was up to date."""
+    """Regenerate public docs. Returns True if every generated region was current."""
     registry = Registry.load(root / "registry.json")
     readme = root / "README.md"
-    original = readme.read_text(encoding="utf-8")
+    readme_original = readme.read_text(encoding="utf-8")
 
-    updated = _replace_region(original, TABLE_START, TABLE_END, render_table(registry))
-    updated = _replace_region(updated, INSTALL_START, INSTALL_END, render_install(registry))
+    readme_updated = _replace_region(
+        readme_original, TABLE_START, TABLE_END, render_table(registry)
+    )
+    readme_updated = _replace_region(
+        readme_updated, INSTALL_START, INSTALL_END, render_install(registry)
+    )
 
-    fresh = updated == original
-    if not check and not fresh:
-        readme.write_text(updated, encoding="utf-8")
+    site = root / "docs" / "registry" / "index.html"
+    site_original = site.read_text(encoding="utf-8")
+    site_updated = _replace_region(
+        site_original,
+        SITE_COUNT_START,
+        SITE_COUNT_END,
+        f"{len(registry.clis)} CLIs",
+    )
+    site_updated = _replace_region(
+        site_updated,
+        SITE_DATA_START,
+        SITE_DATA_END,
+        render_site_data(registry),
+    )
+
+    fresh = readme_updated == readme_original and site_updated == site_original
+    if not check:
+        if readme_updated != readme_original:
+            readme.write_text(readme_updated, encoding="utf-8")
+        if site_updated != site_original:
+            site.write_text(site_updated, encoding="utf-8")
     return fresh

--- a/devkit/cli_web_devkit/registry.py
+++ b/devkit/cli_web_devkit/registry.py
@@ -107,10 +107,31 @@ def validate(root: Path) -> list[str]:
             problems.append(f"{e.name}: name must start with 'cli-web-'")
         if not e.namespace.startswith("cli_web."):
             problems.append(f"{e.name}: namespace must start with 'cli_web.'")
-        if e.directory not in e.install:
-            problems.append(f"{e.name}: install command does not reference {e.directory!r}")
+        if (
+            not e.install.startswith("pip install ")
+            or e.name not in e.install
+            or " -e " in e.install
+        ):
+            problems.append(
+                f"{e.name}: install must be a public PyPI command for {e.name!r}, got {e.install!r}"
+            )
         if not e.commands:
             problems.append(f"{e.name}: commands list is empty")
+        for field_name in ("description", "site_icon", "site_category", "site_tags"):
+            if not e.extra.get(field_name):
+                problems.append(f"{e.name}: missing public site metadata {field_name!r}")
+        readme_candidates = (pkg_dir / "README.md", harness / "README.md")
+        package_readme = next((path for path in readme_candidates if path.is_file()), None)
+        if package_readme is None:
+            problems.append(f"{e.name}: package README is missing")
+        else:
+            readme_text = package_readme.read_text(encoding="utf-8")
+            setup_commands = [e.install, *e.extra.get("post_install", [])]
+            missing_setup = [command for command in setup_commands if command not in readme_text]
+            if missing_setup:
+                problems.append(
+                    f"{e.name}: package README is missing setup commands {missing_setup!r}"
+                )
 
     for harness in sorted(root.glob("*/agent-harness")):
         app_dir = harness.parent.name

--- a/devkit/tests/test_docs.py
+++ b/devkit/tests/test_docs.py
@@ -1,4 +1,6 @@
-from cli_web_devkit.docs import generate, render_install, render_table
+import json
+
+from cli_web_devkit.docs import generate, render_install, render_site_data, render_table
 from cli_web_devkit.paths import repo_root
 from cli_web_devkit.registry import Registry
 
@@ -28,6 +30,18 @@ def test_install_block_covers_whole_fleet():
     assert "```bash" in block
 
 
-def test_real_readme_is_fresh():
-    """README fleet sections must match registry (run `cli-web-devkit docs`)."""
-    assert generate(ROOT, check=True), "README.md fleet sections are stale"
+def test_site_data_has_one_public_install_per_cli():
+    data = render_site_data(REGISTRY)
+    cards = json.loads(data.removeprefix("const data = ").removesuffix(";"))
+    assert len(cards) == len(REGISTRY.clis)
+    cards_by_name = {card["name"]: card for card in cards}
+    for entry in REGISTRY.clis:
+        card = cards_by_name[entry.app_dir]
+        assert card["install"] == entry.install
+        assert card["setup"] == entry.extra.get("post_install", [])
+        assert card["cmds"] == entry.commands
+
+
+def test_public_docs_are_fresh():
+    """README and registry site must match registry (run `cli-web-devkit docs`)."""
+    assert generate(ROOT, check=True), "README.md or registry site generated data is stale"

--- a/docs/registry/index.html
+++ b/docs/registry/index.html
@@ -393,6 +393,13 @@ h1 .cursor {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 8px;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
 }
 
 .badge {
@@ -477,12 +484,11 @@ h1 .cursor {
 .install-row code {
   flex: 1;
   font-family: var(--mono);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   font-size: 11.5px;
   color: var(--text);
   user-select: all;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .copy-btn {
@@ -537,7 +543,9 @@ footer a:hover { color: var(--text); }
   <div class="hero-glow"></div>
   <div class="hero-badge">
     <span class="dot"></span>
-    18 CLIs
+    <!-- fleet-count:start -->
+20 CLIs
+<!-- fleet-count:end -->
     <span class="sep">|</span>
     Updated today
   </div>
@@ -558,6 +566,9 @@ footer a:hover { color: var(--text); }
     <span class="pill" data-f="media">Media</span>
     <span class="pill" data-f="social">Social</span>
     <span class="pill" data-f="ai">AI / Design</span>
+    <span class="pill" data-f="shopping">Shopping</span>
+    <span class="pill" data-f="finance">Finance</span>
+    <span class="pill" data-f="sports">Sports</span>
   </div>
 </section>
 
@@ -576,28 +587,656 @@ footer a:hover { color: var(--text); }
 </footer>
 
 <script>
+// fleet-data:start
 const data = [
-  { name:"stitch", icon:"S", site:"stitch.withgoogle.com", desc:"Google Stitch — AI UI design tool. Generate mobile/web mockups from text prompts, export HTML.", category:"AI / Design", tags:["ai"], proto:"batchexecute RPC", cmds:["projects list","projects create","projects rename","screens list","design generate","design theme"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=stitch/agent-harness", n:16 },
-  { name:"reddit", icon:"R", site:"reddit.com", desc:"Reddit — browse feeds, search posts, view subreddits, vote, comment, submit, save, and manage inbox.", category:"Social", tags:["social"], proto:"REST JSON API (curl_cffi)", cmds:["feed hot","feed new","feed top","sub hot","sub info","sub rules","search posts","search subs","user info","user posts","post get","auth login","me profile","me saved","vote up","submit flairs","submit text","comment add","saved save"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=reddit/agent-harness", n:38 },
-  { name:"booking", icon:"B", site:"booking.com", desc:"Booking.com — search hotels by destination, dates, and filters.", category:"Travel", tags:["travel"], proto:"GraphQL + HTML (curl_cffi)", cmds:["search find","property get","destinations resolve"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=booking/agent-harness", n:6 },
-  { name:"gai", icon:"A", site:"Google AI Mode", desc:"Google AI Mode — AI-powered search with source references.", category:"AI / Design", tags:["ai"], proto:"Browser-rendered (Playwright)", cmds:["search ask"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=gai/agent-harness", n:1 },
-  { name:"notebooklm", icon:"N", site:"notebooklm.google.com", desc:"Google NotebookLM — create notebooks, add sources, chat with AI, generate 9 artifact types.", category:"Productivity", tags:["productivity","ai"], proto:"batchexecute RPC", cmds:["notebooks list","notebooks create","sources add","chat ask","artifacts generate"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=notebooklm/agent-harness", n:16 },
-  { name:"pexels", icon:"P", site:"pexels.com", desc:"Free stock photos and videos — search, download, browse collections and photographer profiles.", category:"Media", tags:["media"], proto:"SSR + __NEXT_DATA__ (curl_cffi)", cmds:["photos search","photos get","photos download","videos search","videos get","videos download","users get","users media","collections get","collections discover"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=pexels/agent-harness", n:10 },
-  { name:"unsplash", icon:"U", site:"unsplash.com", desc:"Unsplash — search and download free high-res photos, browse topics and collections.", category:"Media", tags:["media"], proto:"REST API (curl_cffi)", cmds:["photos search","photos get","photos download","topics list","collections list"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=unsplash/agent-harness", n:15 },
-  { name:"producthunt", icon:"P", site:"producthunt.com", desc:"Product Hunt — today's top launches, leaderboards, and product details.", category:"Developer Tools", tags:["developer"], proto:"HTML scraping (curl_cffi)", cmds:["posts list","posts get","posts leaderboard","users get"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=producthunt/agent-harness", n:4 },
-  { name:"futbin", icon:"F", site:"futbin.com", desc:"EA FC player database — search, compare, prices, market analysis, arbitrage, trading signals, version comparisons.", category:"Gaming", tags:["gaming","trading"], proto:"HTML + JSON API", cmds:["players search","players get","players versions","market analyze","market scan","market arbitrage","sbc list"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=futbin/agent-harness", n:22 },
-  { name:"gh-trending", icon:"G", site:"github.com/trending", desc:"GitHub Trending — browse trending repositories and developers with language and time filters.", category:"Developer Tools", tags:["developer"], proto:"HTML scraping", cmds:["repos list","developers list"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=gh-trending/agent-harness", n:2 },
-  { name:"youtube", icon:"Y", site:"youtube.com", desc:"YouTube — search videos, get details (views, duration, keywords), browse trending, explore channels.", category:"Media", tags:["media"], proto:"InnerTube REST API", cmds:["search videos","video get","trending list","channel get"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=youtube/agent-harness", n:4 },
-  { name:"hackernews", icon:"H", site:"news.ycombinator.com", desc:"Hacker News — browse stories (top/new/best/ask/show/jobs), search, view comments, user profiles, upvote, submit, comment, favorite.", category:"Developer Tools", tags:["developer","social"], proto:"REST API (Firebase + Algolia)", cmds:["stories top","stories new","stories best","stories ask","stories show","stories jobs","stories view","search stories","search comments","user view","user favorites","user submissions","user threads","upvote","submit","comment","favorite","hide","auth login","auth status"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=hackernews/agent-harness", n:20 },
-  { name:"codewiki", icon:"C", site:"codewiki.google", desc:"Google Code Wiki — AI-generated documentation for open source repos, wiki sections, Gemini chat, download as markdown.", category:"Developer Tools", tags:["developer","ai"], proto:"batchexecute RPC", cmds:["repos featured","repos search","wiki get","wiki sections","wiki section","wiki download","chat ask"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=codewiki/agent-harness", n:7 },
-  { name:"chatgpt", icon:"G", site:"chatgpt.com", desc:"ChatGPT — ask questions, generate/download images, list conversations, browse models. Headless Cloudflare bypass via Camoufox.", category:"AI & ML", tags:["ai","images"], proto:"REST API + Camoufox", cmds:["chat ask","chat image","conversations list","conversations get","images list","images download","images styles","models","me","auth login","auth status","auth logout"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=chatgpt/agent-harness", n:12 },
-  { name:"airbnb", icon:"🏠", site:"airbnb.com", desc:"Airbnb — search stays by location/dates/filters, get full listing details (host, amenities, rating), read guest reviews, check availability calendars, autocomplete location names. No auth required.", category:"Travel & Booking", tags:["travel","search","rentals"], proto:"SSR HTML + niobeClientData", cmds:["search stays","listings get","listings reviews","listings availability","autocomplete locations"], install:"pip install git+https://github.com/ItamarZand88/CLI-Anything-WEB.git#subdirectory=airbnb/agent-harness", n:15 },
-  { name:"amazon", icon:"A", site:"amazon.com", desc:"Search Amazon products, view details, browse Best Sellers and get autocomplete suggestions. No auth required.", category:"Shopping", tags:["shopping"], proto:"SSR HTML + REST JSON", auth:"none", cmds:["search","suggest","product get","bestsellers"], install:"pip install -e amazon/agent-harness", n:4 },
-  { name:"tripadvisor", icon:"🌍", site:"tripadvisor.com", desc:"Search TripAdvisor hotels, restaurants, attractions and locations. No auth required. DataDome bypass via curl_cffi.", category:"Travel & Booking", tags:["travel","search"], proto:"SSR HTML + JSON-LD (curl_cffi)", cmds:["locations search","hotels search","hotels get","restaurants search","restaurants get","attractions search","attractions get"], install:"pip install -e tripadvisor/agent-harness", n:7 },
-  { name:"linkedin", icon:"in", site:"linkedin.com", desc:"LinkedIn — search people/jobs/companies, view feed and profiles, post/edit/delete updates, react, comment, manage network connections (accept/decline invitations), read and send messages, follow companies. PerimeterX bypass via curl_cffi.", category:"Social", tags:["social","jobs"], proto:"GraphQL + Voyager REST (curl_cffi)", cmds:["auth login","auth status","auth logout","feed","search all","search people","search companies","search jobs","profile get","profile me","company","company follow","company unfollow","jobs search","jobs get","post create","post edit","post delete","post react","post unreact","post comment","post edit-comment","post delete-comment","notifications","network connections","network invitations","network accept","network decline","network connect","messaging list","messaging read","messaging send"], install:"pip install -e linkedin/agent-harness", n:32 },
-  { name:"capitoltrades", icon:"CT", site:"capitoltrades.com", desc:"US Congressional stock trades (STOCK Act) — browse ~35K trades, 200+ politicians, 3K+ issuers. Filter by party, chamber, ticker, sector, trade size. Rich issuer data with 1-year price history. No auth required.", category:"Finance", tags:["finance","politics"], proto:"SSR HTML + BFF JSON (curl_cffi)", cmds:["trades list","trades get","trades by-ticker","trades stats","politicians list","politicians top","politicians get","issuers list","issuers get","issuers search","articles list","articles get","buzz list","buzz get","press list","press get"], install:"pip install -e capitoltrades/agent-harness", n:16 },
-  { name:"worldcup", icon:"WC", site:"espn.com", desc:"FIFA World Cup 2026 — fixtures (nations games), the 48 qualified teams, national-team squads, group standings, and bookmaker odds. Read-only; no betting. Data from ESPN (no auth) and The Odds API (free key for odds).", category:"Sports", tags:["sports","football","worldcup"], proto:"REST JSON (ESPN + The Odds API)", cmds:["fixtures list","fixtures get","teams list","teams get","players roster","standings list","odds list"], install:"pip install -e worldcup/agent-harness", n:7 },
+  {
+    "name": "futbin",
+    "icon": "F",
+    "site": "FUTBIN",
+    "desc": "EA FC player database — search, compare, prices, market analysis, arbitrage, trading signals",
+    "category": "Gaming",
+    "tags": [
+      "gaming",
+      "trading"
+    ],
+    "proto": "HTML + JSON API",
+    "auth": "None",
+    "cmds": [
+      "players search",
+      "players get",
+      "players list",
+      "players compare",
+      "players price-history",
+      "players versions",
+      "market index",
+      "market popular",
+      "market latest",
+      "market cheapest",
+      "market movers",
+      "market fodder",
+      "market analyze",
+      "market scan",
+      "market arbitrage",
+      "sbc list",
+      "sbc get",
+      "evolutions list",
+      "evolutions get",
+      "config get",
+      "config set",
+      "config show",
+      "config reset"
+    ],
+    "install": "pip install cli-web-futbin",
+    "setup": [],
+    "n": 23,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/futbin"
+  },
+  {
+    "name": "notebooklm",
+    "icon": "N",
+    "site": "Google NotebookLM",
+    "desc": "Notebooks, sources, chat, 9 artifact types (audio, video, slides, quiz, mindmap)",
+    "category": "Productivity",
+    "tags": [
+      "productivity",
+      "ai"
+    ],
+    "proto": "batchexecute RPC",
+    "auth": "Google SSO",
+    "cmds": [
+      "notebooks list",
+      "notebooks create",
+      "notebooks get",
+      "notebooks rename",
+      "notebooks delete",
+      "sources list",
+      "sources get",
+      "sources add-url",
+      "sources add-text",
+      "sources delete",
+      "chat ask",
+      "artifacts list",
+      "artifacts generate",
+      "artifacts generate-notes",
+      "artifacts download",
+      "artifacts list-audio-types",
+      "auth login",
+      "auth refresh",
+      "auth status",
+      "use",
+      "status",
+      "whoami"
+    ],
+    "install": "pip install \"cli-web-notebooklm[auth]\"",
+    "setup": [
+      "playwright install chromium"
+    ],
+    "n": 22,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/notebooklm"
+  },
+  {
+    "name": "gh-trending",
+    "icon": "G",
+    "site": "GitHub Trending",
+    "desc": "Trending repos & developers with language/time filters",
+    "category": "Developer Tools",
+    "tags": [
+      "developer"
+    ],
+    "proto": "HTML scraping",
+    "auth": "None",
+    "cmds": [
+      "repos list",
+      "developers list"
+    ],
+    "install": "pip install cli-web-gh-trending",
+    "setup": [],
+    "n": 2,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/gh-trending"
+  },
+  {
+    "name": "producthunt",
+    "icon": "P",
+    "site": "Product Hunt",
+    "desc": "Today's launches, leaderboards, product details",
+    "category": "Developer Tools",
+    "tags": [
+      "developer"
+    ],
+    "proto": "Next.js RSC flight (curl_cffi)",
+    "auth": "None",
+    "cmds": [
+      "posts list",
+      "posts get",
+      "posts leaderboard",
+      "users get"
+    ],
+    "install": "pip install cli-web-producthunt",
+    "setup": [],
+    "n": 4,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/producthunt"
+  },
+  {
+    "name": "unsplash",
+    "icon": "U",
+    "site": "Unsplash",
+    "desc": "Photo search, download, topics, collections, profiles",
+    "category": "Media",
+    "tags": [
+      "media"
+    ],
+    "proto": "REST JSON (camoufox browser)",
+    "auth": "None",
+    "cmds": [
+      "photos search",
+      "photos get",
+      "photos download",
+      "photos random",
+      "photos stats",
+      "photos autocomplete",
+      "photos related",
+      "topics list",
+      "topics get",
+      "topics photos",
+      "collections search",
+      "collections get",
+      "collections photos",
+      "users search",
+      "users get",
+      "users photos",
+      "users collections"
+    ],
+    "install": "pip install cli-web-unsplash",
+    "setup": [
+      "python -m camoufox fetch"
+    ],
+    "n": 17,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/unsplash"
+  },
+  {
+    "name": "booking",
+    "icon": "B",
+    "site": "Booking.com",
+    "desc": "Hotel search, property details, destination resolution",
+    "category": "Travel & Booking",
+    "tags": [
+      "travel"
+    ],
+    "proto": "GraphQL + HTML (curl_cffi)",
+    "auth": "WAF cookies",
+    "cmds": [
+      "search find",
+      "get",
+      "autocomplete",
+      "auth login",
+      "auth status",
+      "auth logout"
+    ],
+    "install": "pip install \"cli-web-booking[auth]\"",
+    "setup": [
+      "playwright install chromium"
+    ],
+    "n": 6,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/booking"
+  },
+  {
+    "name": "stitch",
+    "icon": "S",
+    "site": "Google Stitch",
+    "desc": "AI UI design — generate mobile/web app mockups from text prompts",
+    "category": "AI & Design",
+    "tags": [
+      "ai"
+    ],
+    "proto": "batchexecute RPC",
+    "auth": "Google SSO",
+    "cmds": [
+      "projects list",
+      "projects get",
+      "projects create",
+      "projects rename",
+      "projects duplicate",
+      "projects delete",
+      "projects download",
+      "screens list",
+      "screens get",
+      "screens download",
+      "design generate",
+      "design theme",
+      "design history",
+      "design assets",
+      "auth login",
+      "auth import",
+      "auth status",
+      "use",
+      "status",
+      "app-config"
+    ],
+    "install": "pip install \"cli-web-stitch[auth]\"",
+    "setup": [
+      "playwright install chromium"
+    ],
+    "n": 20,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/stitch"
+  },
+  {
+    "name": "pexels",
+    "icon": "P",
+    "site": "Pexels",
+    "desc": "Free stock photos & videos — search, download, collections, profiles",
+    "category": "Media",
+    "tags": [
+      "media"
+    ],
+    "proto": "SSR + __NEXT_DATA__ (curl_cffi)",
+    "auth": "None",
+    "cmds": [
+      "photos search",
+      "photos get",
+      "photos download",
+      "photos suggest",
+      "videos search",
+      "videos get",
+      "videos download",
+      "users get",
+      "users media",
+      "collections get",
+      "collections discover"
+    ],
+    "install": "pip install cli-web-pexels",
+    "setup": [],
+    "n": 11,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/pexels"
+  },
+  {
+    "name": "reddit",
+    "icon": "R",
+    "site": "Reddit",
+    "desc": "Feeds, subreddits, search, vote, comment, submit, save, inbox",
+    "category": "Social",
+    "tags": [
+      "social"
+    ],
+    "proto": "REST JSON API (curl_cffi)",
+    "auth": "required (OAuth via token_v2)",
+    "cmds": [
+      "feed hot",
+      "feed new",
+      "feed top",
+      "feed rising",
+      "feed popular",
+      "sub hot",
+      "sub new",
+      "sub top",
+      "sub info",
+      "sub rules",
+      "sub search",
+      "sub join",
+      "sub leave",
+      "search posts",
+      "search subs",
+      "user info",
+      "user posts",
+      "user comments",
+      "post get",
+      "auth login",
+      "auth logout",
+      "auth status",
+      "me profile",
+      "me saved",
+      "me upvoted",
+      "me subscriptions",
+      "me inbox",
+      "vote up",
+      "vote down",
+      "vote unvote",
+      "submit text",
+      "submit link",
+      "submit flairs",
+      "comment add",
+      "comment edit",
+      "comment delete",
+      "saved save",
+      "saved unsave"
+    ],
+    "install": "pip install cli-web-reddit",
+    "setup": [
+      "playwright install chromium"
+    ],
+    "n": 38,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/reddit"
+  },
+  {
+    "name": "gai",
+    "icon": "A",
+    "site": "Google AI Mode",
+    "desc": "AI-powered search with source references",
+    "category": "AI & ML",
+    "tags": [
+      "ai"
+    ],
+    "proto": "Browser-rendered (Playwright)",
+    "auth": "None",
+    "cmds": [
+      "search ask",
+      "search followup"
+    ],
+    "install": "pip install cli-web-gai",
+    "setup": [
+      "playwright install chromium"
+    ],
+    "n": 2,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/gai"
+  },
+  {
+    "name": "youtube",
+    "icon": "Y",
+    "site": "YouTube",
+    "desc": "Search videos, video details, trending, channel info",
+    "category": "Media",
+    "tags": [
+      "media"
+    ],
+    "proto": "InnerTube REST API (httpx)",
+    "auth": "None",
+    "cmds": [
+      "search videos",
+      "video get",
+      "trending list",
+      "channel get",
+      "transcript get",
+      "transcript list"
+    ],
+    "install": "pip install cli-web-youtube",
+    "setup": [],
+    "n": 6,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/youtube"
+  },
+  {
+    "name": "hackernews",
+    "icon": "H",
+    "site": "Hacker News",
+    "desc": "Stories, search, comments, users, upvote, submit, comment, favorite",
+    "category": "Developer Tools",
+    "tags": [
+      "developer",
+      "social"
+    ],
+    "proto": "REST API — Firebase + Algolia (httpx)",
+    "auth": "Cookie (optional)",
+    "cmds": [
+      "stories top",
+      "stories new",
+      "stories best",
+      "stories ask",
+      "stories show",
+      "stories jobs",
+      "stories view",
+      "stories max-item",
+      "stories updates",
+      "search stories",
+      "search comments",
+      "user view",
+      "user favorites",
+      "user submissions",
+      "user threads",
+      "auth login",
+      "auth login-browser",
+      "auth status",
+      "auth logout",
+      "upvote",
+      "submit",
+      "comment",
+      "favorite",
+      "hide"
+    ],
+    "install": "pip install cli-web-hackernews",
+    "setup": [],
+    "n": 24,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/hackernews"
+  },
+  {
+    "name": "codewiki",
+    "icon": "C",
+    "site": "Google Code Wiki",
+    "desc": "AI-generated repo docs, wiki sections, Gemini chat, download as .md",
+    "category": "Developer Tools",
+    "tags": [
+      "developer",
+      "ai"
+    ],
+    "proto": "batchexecute RPC",
+    "auth": "None",
+    "cmds": [
+      "repos featured",
+      "repos search",
+      "wiki get",
+      "wiki sections",
+      "wiki section",
+      "wiki download",
+      "chat ask"
+    ],
+    "install": "pip install cli-web-codewiki",
+    "setup": [],
+    "n": 7,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/codewiki"
+  },
+  {
+    "name": "chatgpt",
+    "icon": "G",
+    "site": "ChatGPT",
+    "desc": "Ask questions, generate/download images, conversations, models",
+    "category": "AI & ML",
+    "tags": [
+      "ai"
+    ],
+    "proto": "REST API + Camoufox browser",
+    "auth": "Browser (OpenAI SSO)",
+    "cmds": [
+      "chat ask",
+      "chat image",
+      "conversations list",
+      "conversations get",
+      "images list",
+      "images download",
+      "images styles",
+      "models",
+      "me",
+      "auth login",
+      "auth status",
+      "auth logout"
+    ],
+    "install": "pip install \"cli-web-chatgpt[auth]\"",
+    "setup": [
+      "python -m camoufox fetch",
+      "playwright install chromium"
+    ],
+    "n": 12,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/chatgpt"
+  },
+  {
+    "name": "airbnb",
+    "icon": "A",
+    "site": "Airbnb",
+    "desc": "Search stays, listing details, amenities, host info, autocomplete locations",
+    "category": "Travel & Booking",
+    "tags": [
+      "travel"
+    ],
+    "proto": "SSR HTML + niobeClientData (curl_cffi)",
+    "auth": "None",
+    "cmds": [
+      "search stays",
+      "listings get",
+      "listings reviews",
+      "listings availability",
+      "autocomplete locations"
+    ],
+    "install": "pip install cli-web-airbnb",
+    "setup": [],
+    "n": 5,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/airbnb"
+  },
+  {
+    "name": "amazon",
+    "icon": "A",
+    "site": "amazon.com",
+    "desc": "Search products, view details, browse bestsellers",
+    "category": "Shopping",
+    "tags": [
+      "shopping"
+    ],
+    "proto": "SSR HTML + REST JSON (curl_cffi)",
+    "auth": "None",
+    "cmds": [
+      "search",
+      "suggest",
+      "product get",
+      "bestsellers"
+    ],
+    "install": "pip install cli-web-amazon",
+    "setup": [],
+    "n": 4,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/amazon"
+  },
+  {
+    "name": "tripadvisor",
+    "icon": "T",
+    "site": "TripAdvisor",
+    "desc": "Search locations, hotels, restaurants, and attractions",
+    "category": "Travel & Booking",
+    "tags": [
+      "travel"
+    ],
+    "proto": "SSR HTML + JSON-LD (curl_cffi)",
+    "auth": "None",
+    "cmds": [
+      "locations search",
+      "hotels search",
+      "hotels get",
+      "restaurants search",
+      "restaurants get",
+      "attractions search",
+      "attractions get"
+    ],
+    "install": "pip install cli-web-tripadvisor",
+    "setup": [],
+    "n": 7,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/tripadvisor"
+  },
+  {
+    "name": "linkedin",
+    "icon": "in",
+    "site": "LinkedIn",
+    "desc": "Search, feed, profiles, jobs, posts, reactions, comments, network, and messaging",
+    "category": "Social",
+    "tags": [
+      "social"
+    ],
+    "proto": "GraphQL + Voyager REST (curl_cffi)",
+    "auth": "Cookie",
+    "cmds": [
+      "auth login",
+      "auth status",
+      "auth logout",
+      "feed",
+      "search all",
+      "search people",
+      "search companies",
+      "search jobs",
+      "profile get",
+      "profile me",
+      "company get",
+      "company follow",
+      "company unfollow",
+      "jobs search",
+      "jobs get",
+      "post create",
+      "post edit",
+      "post delete",
+      "post react",
+      "post unreact",
+      "post comment",
+      "post edit-comment",
+      "post delete-comment",
+      "notifications",
+      "network connections",
+      "network invitations",
+      "network accept",
+      "network decline",
+      "network connect",
+      "messaging list",
+      "messaging read",
+      "messaging send"
+    ],
+    "install": "pip install \"cli-web-linkedin[browser]\"",
+    "setup": [
+      "playwright install chromium"
+    ],
+    "n": 32,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/linkedin"
+  },
+  {
+    "name": "capitoltrades",
+    "icon": "CT",
+    "site": "Capitol Trades",
+    "desc": "US congressional stock trades (STOCK Act) — trades, politicians, issuers, price history",
+    "category": "Finance",
+    "tags": [
+      "finance"
+    ],
+    "proto": "SSR HTML + BFF JSON (curl_cffi)",
+    "auth": "None",
+    "cmds": [
+      "trades list",
+      "trades get",
+      "trades by-ticker",
+      "trades stats",
+      "politicians list",
+      "politicians top",
+      "politicians get",
+      "issuers list",
+      "issuers get",
+      "issuers search",
+      "articles list",
+      "articles get",
+      "buzz list",
+      "buzz get",
+      "press list",
+      "press get"
+    ],
+    "install": "pip install cli-web-capitoltrades",
+    "setup": [],
+    "n": 16,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/capitoltrades"
+  },
+  {
+    "name": "worldcup",
+    "icon": "WC",
+    "site": "ESPN / FIFA World Cup 2026",
+    "desc": "FIFA World Cup 2026 — fixtures, nations, squads, group standings, and bookmaker odds (read-only)",
+    "category": "Sports",
+    "tags": [
+      "sports"
+    ],
+    "proto": "REST JSON (ESPN + The Odds API)",
+    "auth": "None",
+    "cmds": [
+      "fixtures list",
+      "fixtures get",
+      "teams list",
+      "teams get",
+      "players roster",
+      "standings list",
+      "odds list"
+    ],
+    "install": "pip install cli-web-worldcup",
+    "setup": [],
+    "n": 7,
+    "url": "https://github.com/ItamarZand88/CLI-Anything-WEB/tree/main/worldcup"
+  }
 ];
+// fleet-data:end
 
 const grid = document.getElementById('grid');
 const search = document.getElementById('search');
@@ -609,6 +1248,7 @@ function render(filter='all', q='') {
     if (filter !== 'all' && !c.tags.includes(filter)) return;
     if (ql && !c.name.includes(ql) && !c.site.toLowerCase().includes(ql) && !c.desc.toLowerCase().includes(ql) && !c.proto.toLowerCase().includes(ql)) return;
     const el = document.createElement('div');
+    const installCommands = [c.install, ...(c.setup || [])];
     el.className = 'card';
     el.innerHTML = `
       <div class="card-top">
@@ -616,22 +1256,32 @@ function render(filter='all', q='') {
           <span class="card-icon">${c.icon}</span>
           <span class="card-title">${c.name}</span>
         </div>
-        <span class="card-arrow">↗</span>
+        <a class="card-arrow" href="${c.url}" aria-label="Open ${c.name} on GitHub">↗</a>
       </div>
       <div class="card-desc">${c.desc}</div>
       <div class="card-bottom">
-        <span class="badge">${c.category}</span>
+        <div class="badge-row">
+          <span class="badge">${c.category}</span>
+          <span class="badge">${c.auth}</span>
+        </div>
         <span class="stars">${c.n} commands</span>
       </div>
       <div class="card-expand">
         <div class="expand-inner">
           <div class="cmd-list">${c.cmds.map(x=>`<span class="cmd">${x}</span>`).join('')}</div>
           <div class="install-row">
-            <code>${c.install}</code>
-            <button class="copy-btn" data-cmd="${c.install}" onclick="event.stopPropagation();navigator.clipboard.writeText(this.dataset.cmd);this.textContent='Copied';setTimeout(()=>this.textContent='Copy',1200)">Copy</button>
+            <code>${installCommands.join('\n')}</code>
+            <button class="copy-btn">Copy</button>
           </div>
         </div>
       </div>`;
+    const copyButton = el.querySelector('.copy-btn');
+    copyButton.onclick = event => {
+      event.stopPropagation();
+      navigator.clipboard.writeText(installCommands.join('\n'));
+      copyButton.textContent = 'Copied';
+      setTimeout(() => { copyButton.textContent = 'Copy'; }, 1200);
+    };
     grid.appendChild(el);
   });
 }

--- a/futbin/agent-harness/cli_web/futbin/README.md
+++ b/futbin/agent-harness/cli_web/futbin/README.md
@@ -8,8 +8,7 @@ Search players, check prices, compare stats, browse SBCs and Evolutions.
 ## Installation
 
 ```bash
-cd futbin/agent-harness
-pip install -e .
+pip install cli-web-futbin
 ```
 
 No authentication required — FUTBIN is a public site.

--- a/gai/agent-harness/cli_web/gai/README.md
+++ b/gai/agent-harness/cli_web/gai/README.md
@@ -6,6 +6,7 @@ CLI for Google AI Mode — submit questions and get AI-generated answers with so
 
 ```bash
 pip install cli-web-gai
+playwright install chromium
 ```
 
 ## Usage

--- a/gh-trending/agent-harness/cli_web/gh_trending/README.md
+++ b/gh-trending/agent-harness/cli_web/gh_trending/README.md
@@ -5,8 +5,7 @@ A CLI for [GitHub Trending](https://github.com/trending) — explore trending re
 ## Installation
 
 ```bash
-cd gh-trending/agent-harness
-pip install -e .
+pip install cli-web-gh-trending
 ```
 
 ## Usage

--- a/hackernews/agent-harness/cli_web/hackernews/README.md
+++ b/hackernews/agent-harness/cli_web/hackernews/README.md
@@ -5,8 +5,7 @@ CLI for browsing and interacting with Hacker News — top stories, search, comme
 ## Installation
 
 ```bash
-cd hackernews/agent-harness
-pip install -e .
+pip install cli-web-hackernews
 ```
 
 ## Usage

--- a/linkedin/agent-harness/cli_web/linkedin/README.md
+++ b/linkedin/agent-harness/cli_web/linkedin/README.md
@@ -9,7 +9,8 @@ Search LinkedIn for people, jobs, and companies. View profiles, feed, and compan
 ## Installation
 
 ```bash
-pip install cli-web-linkedin
+pip install "cli-web-linkedin[browser]"
+playwright install chromium
 ```
 
 ## Authentication

--- a/linkedin/agent-harness/cli_web/linkedin/skills/SKILL.md
+++ b/linkedin/agent-harness/cli_web/linkedin/skills/SKILL.md
@@ -10,7 +10,8 @@ LinkedIn CLI — 26 commands across 10 groups: auth, feed, search, profile, comp
 ## Quick Start
 
 ```bash
-pip install cli-web-linkedin
+pip install "cli-web-linkedin[browser]"
+playwright install chromium
 cli-web-linkedin auth login           # Browser login (required)
 cli-web-linkedin feed --json
 cli-web-linkedin search people "python developer" --json

--- a/notebooklm/agent-harness/cli_web/notebooklm/README.md
+++ b/notebooklm/agent-harness/cli_web/notebooklm/README.md
@@ -7,7 +7,8 @@ Agent-native CLI for Google NotebookLM — create notebooks, add sources, ask qu
 ## Installation
 
 ```bash
-pip install -e .
+pip install "cli-web-notebooklm[auth]"
+playwright install chromium
 ```
 
 ## Auth

--- a/pexels/agent-harness/cli_web/pexels/README.md
+++ b/pexels/agent-harness/cli_web/pexels/README.md
@@ -5,8 +5,7 @@ CLI for [Pexels](https://www.pexels.com/) — free stock photos and videos from 
 ## Installation
 
 ```bash
-cd pexels/agent-harness
-pip install -e .
+pip install cli-web-pexels
 ```
 
 ## Usage

--- a/producthunt/agent-harness/cli_web/producthunt/README.md
+++ b/producthunt/agent-harness/cli_web/producthunt/README.md
@@ -7,8 +7,7 @@ CLI for browsing Product Hunt — today's top launches, leaderboards, product de
 ## Installation
 
 ```bash
-cd producthunt/agent-harness
-pip install -e .
+pip install cli-web-producthunt
 cli-web-producthunt --help
 ```
 

--- a/reddit/agent-harness/cli_web/reddit/README.md
+++ b/reddit/agent-harness/cli_web/reddit/README.md
@@ -5,8 +5,8 @@ CLI for Reddit browsing and search. Browse feeds, subreddits, search posts, view
 ## Installation
 
 ```bash
-cd reddit/agent-harness
-pip install -e .
+pip install cli-web-reddit
+playwright install chromium
 ```
 
 ## Quick Start

--- a/registry.json
+++ b/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "clis": [
     {
       "name": "cli-web-futbin",
@@ -27,12 +27,13 @@
         "sbc list",
         "sbc get",
         "evolutions list",
-        "evolutions get",
-        "config set",
+      "evolutions get",
+      "config get",
+      "config set",
         "config show",
         "config reset"
       ],
-      "install": "pip install -e futbin/agent-harness",
+      "install": "pip install cli-web-futbin",
       "canary": [
         [
           "market",
@@ -42,7 +43,10 @@
       ],
       "display_website": "FUTBIN",
       "skill": ".claude/skills/futbin-cli/SKILL.md",
-      "description": "EA FC player database — search, compare, prices, market analysis, arbitrage, trading signals"
+      "description": "EA FC player database — search, compare, prices, market analysis, arbitrage, trading signals",
+      "site_icon": "F",
+      "site_category": "Gaming",
+      "site_tags": ["gaming", "trading"]
     },
     {
       "name": "cli-web-notebooklm",
@@ -52,16 +56,37 @@
       "directory": "notebooklm/agent-harness",
       "namespace": "cli_web.notebooklm",
       "commands": [
-        "notebooks list",
-        "notebooks create",
-        "sources add",
-        "chat ask",
-        "artifacts generate"
+      "notebooks list",
+      "notebooks create",
+      "notebooks get",
+      "notebooks rename",
+      "notebooks delete",
+      "sources list",
+      "sources get",
+      "sources add-url",
+      "sources add-text",
+      "sources delete",
+      "chat ask",
+      "artifacts list",
+      "artifacts generate",
+      "artifacts generate-notes",
+      "artifacts download",
+      "artifacts list-audio-types",
+      "auth login",
+      "auth refresh",
+      "auth status",
+      "use",
+      "status",
+      "whoami"
       ],
-      "install": "pip install -e notebooklm/agent-harness",
+      "install": "pip install \"cli-web-notebooklm[auth]\"",
       "display_website": "Google NotebookLM",
       "skill": ".claude/skills/notebooklm-cli/SKILL.md",
-      "description": "Notebooks, sources, chat, 9 artifact types (audio, video, slides, quiz, mindmap)"
+      "description": "Notebooks, sources, chat, 9 artifact types (audio, video, slides, quiz, mindmap)",
+      "site_icon": "N",
+      "site_category": "Productivity",
+      "site_tags": ["productivity", "ai"],
+      "post_install": ["playwright install chromium"]
     },
     {
       "name": "cli-web-gh-trending",
@@ -74,7 +99,7 @@
         "repos list",
         "developers list"
       ],
-      "install": "pip install -e gh-trending/agent-harness",
+      "install": "pip install cli-web-gh-trending",
       "canary": [
         [
           "repos",
@@ -84,7 +109,10 @@
       ],
       "display_website": "GitHub Trending",
       "skill": ".claude/skills/gh-trending-cli/SKILL.md",
-      "description": "Trending repos & developers with language/time filters"
+      "description": "Trending repos & developers with language/time filters",
+      "site_icon": "G",
+      "site_category": "Developer Tools",
+      "site_tags": ["developer"]
     },
     {
       "name": "cli-web-producthunt",
@@ -94,10 +122,12 @@
       "directory": "producthunt/agent-harness",
       "namespace": "cli_web.producthunt",
       "commands": [
-        "posts list",
-        "posts get"
+      "posts list",
+      "posts get",
+      "posts leaderboard",
+      "users get"
       ],
-      "install": "pip install -e producthunt/agent-harness",
+      "install": "pip install cli-web-producthunt",
       "canary": [
         [
           "posts",
@@ -107,7 +137,10 @@
       ],
       "display_website": "Product Hunt",
       "skill": ".claude/skills/producthunt-cli/SKILL.md",
-      "description": "Today's launches, leaderboards, product details"
+      "description": "Today's launches, leaderboards, product details",
+      "site_icon": "P",
+      "site_category": "Developer Tools",
+      "site_tags": ["developer"]
     },
     {
       "name": "cli-web-unsplash",
@@ -117,12 +150,25 @@
       "directory": "unsplash/agent-harness",
       "namespace": "cli_web.unsplash",
       "commands": [
-        "photos search",
-        "photos get",
-        "photos download",
-        "topics list"
+      "photos search",
+      "photos get",
+      "photos download",
+      "photos random",
+      "photos stats",
+      "photos autocomplete",
+      "photos related",
+      "topics list",
+      "topics get",
+      "topics photos",
+      "collections search",
+      "collections get",
+      "collections photos",
+      "users search",
+      "users get",
+      "users photos",
+      "users collections"
       ],
-      "install": "pip install -e unsplash/agent-harness",
+      "install": "pip install cli-web-unsplash",
       "canary": [
         [
           "photos",
@@ -133,7 +179,11 @@
       ],
       "display_website": "Unsplash",
       "skill": ".claude/skills/unsplash-cli/SKILL.md",
-      "description": "Photo search, download, topics, collections, profiles"
+      "description": "Photo search, download, topics, collections, profiles",
+      "site_icon": "U",
+      "site_category": "Media",
+      "site_tags": ["media"],
+      "post_install": ["python -m camoufox fetch"]
     },
     {
       "name": "cli-web-booking",
@@ -150,10 +200,14 @@
         "auth status",
         "auth logout"
       ],
-      "install": "pip install -e booking/agent-harness",
+      "install": "pip install \"cli-web-booking[auth]\"",
       "display_website": "Booking.com",
       "skill": ".claude/skills/booking-cli/SKILL.md",
-      "description": "Hotel search, property details, destination resolution"
+      "description": "Hotel search, property details, destination resolution",
+      "site_icon": "B",
+      "site_category": "Travel & Booking",
+      "site_tags": ["travel"],
+      "post_install": ["playwright install chromium"]
     },
     {
       "name": "cli-web-stitch",
@@ -163,8 +217,9 @@
       "directory": "stitch/agent-harness",
       "namespace": "cli_web.stitch",
       "commands": [
-        "projects list",
-        "projects create",
+      "projects list",
+      "projects get",
+      "projects create",
         "projects rename",
         "projects duplicate",
         "projects delete",
@@ -172,14 +227,25 @@
         "screens list",
         "screens get",
         "screens download",
-        "design generate",
-        "design theme",
-        "design history"
+      "design generate",
+      "design theme",
+      "design history",
+      "design assets",
+      "auth login",
+      "auth import",
+      "auth status",
+      "use",
+      "status",
+      "app-config"
       ],
-      "install": "pip install -e stitch/agent-harness",
+      "install": "pip install \"cli-web-stitch[auth]\"",
       "display_website": "Google Stitch",
       "skill": ".claude/skills/stitch-cli/SKILL.md",
-      "description": "AI UI design — generate mobile/web app mockups from text prompts"
+      "description": "AI UI design — generate mobile/web app mockups from text prompts",
+      "site_icon": "S",
+      "site_category": "AI & Design",
+      "site_tags": ["ai"],
+      "post_install": ["playwright install chromium"]
     },
     {
       "name": "cli-web-pexels",
@@ -190,8 +256,9 @@
       "namespace": "cli_web.pexels",
       "commands": [
         "photos search",
-        "photos get",
-        "photos download",
+      "photos get",
+      "photos download",
+      "photos suggest",
         "videos search",
         "videos get",
         "videos download",
@@ -200,7 +267,7 @@
         "collections get",
         "collections discover"
       ],
-      "install": "pip install -e pexels/agent-harness",
+      "install": "pip install cli-web-pexels",
       "canary": [
         [
           "photos",
@@ -211,7 +278,10 @@
       ],
       "display_website": "Pexels",
       "skill": ".claude/skills/pexels-cli/SKILL.md",
-      "description": "Free stock photos & videos — search, download, collections, profiles"
+      "description": "Free stock photos & videos — search, download, collections, profiles",
+      "site_icon": "P",
+      "site_category": "Media",
+      "site_tags": ["media"]
     },
     {
       "name": "cli-web-reddit",
@@ -251,18 +321,23 @@
         "vote up",
         "vote down",
         "vote unvote",
-        "submit text",
-        "submit link",
+      "submit text",
+      "submit link",
+      "submit flairs",
         "comment add",
         "comment edit",
         "comment delete",
         "saved save",
         "saved unsave"
       ],
-      "install": "pip install -e reddit/agent-harness",
+      "install": "pip install cli-web-reddit",
       "display_website": "Reddit",
       "skill": ".claude/skills/reddit-cli/SKILL.md",
-      "description": "Feeds, subreddits, search, vote, comment, submit, save, inbox"
+      "description": "Feeds, subreddits, search, vote, comment, submit, save, inbox",
+      "site_icon": "R",
+      "site_category": "Social",
+      "site_tags": ["social"],
+      "post_install": ["playwright install chromium"]
     },
     {
       "name": "cli-web-gai",
@@ -275,7 +350,7 @@
         "search ask",
         "search followup"
       ],
-      "install": "pip install -e gai/agent-harness",
+      "install": "pip install cli-web-gai",
       "canary": [
         [
           "search",
@@ -288,7 +363,11 @@
       ],
       "display_website": "Google AI Mode",
       "skill": ".claude/skills/gai-cli/SKILL.md",
-      "description": "AI-powered search with source references"
+      "description": "AI-powered search with source references",
+      "site_icon": "A",
+      "site_category": "AI & ML",
+      "site_tags": ["ai"],
+      "post_install": ["playwright install chromium"]
     },
     {
       "name": "cli-web-youtube",
@@ -305,7 +384,7 @@
         "transcript get",
         "transcript list"
       ],
-      "install": "pip install -e youtube/agent-harness",
+      "install": "pip install cli-web-youtube",
       "canary": [
         [
           "search",
@@ -318,7 +397,10 @@
       ],
       "display_website": "YouTube",
       "skill": ".claude/skills/youtube-cli/SKILL.md",
-      "description": "Search videos, video details, trending, channel info"
+      "description": "Search videos, video details, trending, channel info",
+      "site_icon": "Y",
+      "site_category": "Media",
+      "site_tags": ["media"]
     },
     {
       "name": "cli-web-hackernews",
@@ -333,8 +415,10 @@
         "stories best",
         "stories ask",
         "stories show",
-        "stories jobs",
-        "stories view",
+      "stories jobs",
+      "stories view",
+      "stories max-item",
+      "stories updates",
         "search stories",
         "search comments",
         "user view",
@@ -351,7 +435,7 @@
         "favorite",
         "hide"
       ],
-      "install": "pip install -e hackernews/agent-harness",
+      "install": "pip install cli-web-hackernews",
       "canary": [
         [
           "stories",
@@ -363,7 +447,10 @@
       ],
       "display_website": "Hacker News",
       "skill": ".claude/skills/hackernews-cli/SKILL.md",
-      "description": "Stories, search, comments, users, upvote, submit, comment, favorite"
+      "description": "Stories, search, comments, users, upvote, submit, comment, favorite",
+      "site_icon": "H",
+      "site_category": "Developer Tools",
+      "site_tags": ["developer", "social"]
     },
     {
       "name": "cli-web-codewiki",
@@ -376,11 +463,12 @@
         "repos featured",
         "repos search",
         "wiki get",
-        "wiki sections",
-        "wiki section",
-        "chat ask"
+      "wiki sections",
+      "wiki section",
+      "wiki download",
+      "chat ask"
       ],
-      "install": "pip install -e codewiki/agent-harness",
+      "install": "pip install cli-web-codewiki",
       "canary": [
         [
           "repos",
@@ -390,7 +478,10 @@
       ],
       "display_website": "Google Code Wiki",
       "skill": ".claude/skills/codewiki-cli/SKILL.md",
-      "description": "AI-generated repo docs, wiki sections, Gemini chat, download as .md"
+      "description": "AI-generated repo docs, wiki sections, Gemini chat, download as .md",
+      "site_icon": "C",
+      "site_category": "Developer Tools",
+      "site_tags": ["developer", "ai"]
     },
     {
       "name": "cli-web-chatgpt",
@@ -413,10 +504,14 @@
         "auth status",
         "auth logout"
       ],
-      "install": "pip install -e chatgpt/agent-harness",
+      "install": "pip install \"cli-web-chatgpt[auth]\"",
       "display_website": "ChatGPT",
       "skill": ".claude/skills/chatgpt-cli/SKILL.md",
-      "description": "Ask questions, generate/download images, conversations, models"
+      "description": "Ask questions, generate/download images, conversations, models",
+      "site_icon": "G",
+      "site_category": "AI & ML",
+      "site_tags": ["ai"],
+      "post_install": ["python -m camoufox fetch", "playwright install chromium"]
     },
     {
       "name": "cli-web-airbnb",
@@ -432,7 +527,7 @@
         "listings availability",
         "autocomplete locations"
       ],
-      "install": "pip install -e airbnb/agent-harness",
+      "install": "pip install cli-web-airbnb",
       "canary": [
         [
           "autocomplete",
@@ -443,7 +538,10 @@
       ],
       "display_website": "Airbnb",
       "skill": ".claude/skills/airbnb-cli/SKILL.md",
-      "description": "Search stays, listing details, amenities, host info, autocomplete locations"
+      "description": "Search stays, listing details, amenities, host info, autocomplete locations",
+      "site_icon": "A",
+      "site_category": "Travel & Booking",
+      "site_tags": ["travel"]
     },
     {
       "name": "cli-web-amazon",
@@ -458,7 +556,7 @@
         "product get",
         "bestsellers"
       ],
-      "install": "pip install -e amazon/agent-harness",
+      "install": "pip install cli-web-amazon",
       "canary": [
         [
           "search",
@@ -468,7 +566,10 @@
       ],
       "display_website": "amazon.com",
       "skill": ".claude/skills/amazon-cli/SKILL.md",
-      "description": "Search products, view details, browse bestsellers"
+      "description": "Search products, view details, browse bestsellers",
+      "site_icon": "A",
+      "site_category": "Shopping",
+      "site_tags": ["shopping"]
     },
     {
       "name": "cli-web-tripadvisor",
@@ -486,7 +587,7 @@
         "attractions search",
         "attractions get"
       ],
-      "install": "pip install -e tripadvisor/agent-harness",
+      "install": "pip install cli-web-tripadvisor",
       "canary": [
         [
           "locations",
@@ -497,7 +598,10 @@
       ],
       "display_website": "TripAdvisor",
       "skill": ".claude/skills/tripadvisor-cli/SKILL.md",
-      "description": "Search locations, hotels, restaurants, and attractions"
+      "description": "Search locations, hotels, restaurants, and attractions",
+      "site_icon": "T",
+      "site_category": "Travel & Booking",
+      "site_tags": ["travel"]
     },
     {
       "name": "cli-web-linkedin",
@@ -517,7 +621,7 @@
         "search jobs",
         "profile get",
         "profile me",
-        "company",
+      "company get",
         "company follow",
         "company unfollow",
         "jobs search",
@@ -540,10 +644,14 @@
         "messaging read",
         "messaging send"
       ],
-      "install": "pip install -e linkedin/agent-harness",
+      "install": "pip install \"cli-web-linkedin[browser]\"",
       "display_website": "LinkedIn",
       "skill": ".claude/skills/linkedin-cli/SKILL.md",
-      "description": "Search, feed, profiles, jobs, posts, reactions, comments, network, messaging (26 cmds)"
+      "description": "Search, feed, profiles, jobs, posts, reactions, comments, network, and messaging",
+      "site_icon": "in",
+      "site_category": "Social",
+      "site_tags": ["social"],
+      "post_install": ["playwright install chromium"]
     },
     {
       "name": "cli-web-capitoltrades",
@@ -570,7 +678,7 @@
         "press list",
         "press get"
       ],
-      "install": "pip install -e capitoltrades/agent-harness",
+      "install": "pip install cli-web-capitoltrades",
       "canary": [
         [
           "--json",
@@ -580,7 +688,10 @@
       ],
       "display_website": "Capitol Trades",
       "skill": ".claude/skills/capitoltrades-cli/SKILL.md",
-      "description": "US congressional stock trades (STOCK Act) — trades, politicians, issuers, price history"
+      "description": "US congressional stock trades (STOCK Act) — trades, politicians, issuers, price history",
+      "site_icon": "CT",
+      "site_category": "Finance",
+      "site_tags": ["finance"]
     },
     {
       "name": "cli-web-worldcup",
@@ -598,7 +709,7 @@
         "standings list",
         "odds list"
       ],
-      "install": "pip install -e worldcup/agent-harness",
+      "install": "pip install cli-web-worldcup",
       "canary": [
         [
           "teams",
@@ -608,7 +719,10 @@
       ],
       "display_website": "ESPN / FIFA World Cup 2026",
       "skill": ".claude/skills/worldcup-cli/SKILL.md",
-      "description": "FIFA World Cup 2026 — fixtures, nations, squads, group standings, and bookmaker odds (read-only)"
+      "description": "FIFA World Cup 2026 — fixtures, nations, squads, group standings, and bookmaker odds (read-only)",
+      "site_icon": "WC",
+      "site_category": "Sports",
+      "site_tags": ["sports"]
     }
   ]
 }

--- a/stitch/agent-harness/cli_web/stitch/README.md
+++ b/stitch/agent-harness/cli_web/stitch/README.md
@@ -5,14 +5,8 @@ Command-line interface for Google Stitch, the AI-powered design tool. Create, ma
 ## Installation
 
 ```bash
-cd stitch/agent-harness
-pip install -e .
-```
-
-For browser-based authentication (Google login):
-
-```bash
-pip install -e ".[auth]"
+pip install "cli-web-stitch[auth]"
+playwright install chromium
 ```
 
 ## Authentication

--- a/tests/contract/test_fleet.py
+++ b/tests/contract/test_fleet.py
@@ -16,6 +16,10 @@ Run: ``pytest tests/contract -m contract``
 
 from __future__ import annotations
 
+import importlib
+from importlib.metadata import entry_points
+
+import click
 import pytest
 from cli_web_core.testing import (
     assert_help_works,
@@ -67,3 +71,47 @@ def test_registered_command_groups_in_help(entry, cli_cmds):
     groups = {c.split()[0] for c in entry.commands}
     missing = [g for g in sorted(groups) if g not in help_text]
     assert not missing, f"{entry.name}: registry commands missing from --help: {missing}"
+
+
+def _installed_command_paths(entry_name: str) -> set[str]:
+    """Return the installed Click leaf commands, excluding fleet utilities."""
+    ep = next(ep for ep in entry_points(group="console_scripts") if ep.name == entry_name)
+    module = importlib.import_module(ep.module)
+    root = next(
+        (
+            candidate
+            for attr in ("cli", "main")
+            if isinstance((candidate := getattr(module, attr, None)), click.Group)
+        ),
+        None,
+    )
+    if root is None:
+        loaded = ep.load()
+        assert isinstance(loaded, click.Group), f"{entry_name}: Click root group not found"
+        root = loaded
+
+    paths: set[str] = set()
+
+    def walk(command: click.Command, path: list[str]) -> None:
+        if isinstance(command, click.Group):
+            context = click.Context(command)
+            for name in command.list_commands(context):
+                child = command.get_command(context, name)
+                if child is not None:
+                    walk(child, [*path, name])
+        elif path:
+            paths.add(" ".join(path))
+
+    walk(root, [])
+    return paths - {"doctor", "mcp-serve"}
+
+
+@pytest.mark.parametrize("entry", _params())
+def test_registry_lists_every_installed_command(entry):
+    """The README and registry site command lists must match the installed CLI."""
+    installed = _installed_command_paths(entry.name)
+    registered = set(entry.commands)
+    assert registered == installed, (
+        f"{entry.name}: registry command drift; "
+        f"missing={sorted(installed - registered)}, stale={sorted(registered - installed)}"
+    )

--- a/tripadvisor/agent-harness/cli_web/tripadvisor/README.md
+++ b/tripadvisor/agent-harness/cli_web/tripadvisor/README.md
@@ -10,8 +10,7 @@ protection is bypassed with curl_cffi Safari-iOS impersonation.
 ## Installation
 
 ```bash
-cd tripadvisor/agent-harness
-pip install -e .
+pip install cli-web-tripadvisor
 ```
 
 Binary: `cli-web-tripadvisor`

--- a/unsplash/agent-harness/cli_web/unsplash/README.md
+++ b/unsplash/agent-harness/cli_web/unsplash/README.md
@@ -6,8 +6,7 @@ No API key or authentication required.
 ## Installation
 
 ```bash
-cd unsplash/agent-harness
-pip install -e .
+pip install cli-web-unsplash
 python -m camoufox fetch   # one-time: downloads the stealth browser used to bypass the anti-bot challenge
 ```
 


### PR DESCRIPTION
## Summary
- replace clone-only installation snippets with current PyPI package commands and required browser setup
- generate the registry site count/cards from registry.json alongside the README
- synchronize all 20 command inventories and enforce docs/CLI parity in CI
- update plugin quickstarts and per-package installation guides

## Verification
- ruff check and format: pass
- mypy devkit/core: pass
- root pytest suite: pass
- devkit + fleet contract: 218 passed
- strict checklist: 20/20 pass
- plugin verification: 28/28 pass
- PyPI package/version/extra verification: 20/20 plus umbrella pass
- local Playwright visual check: pass